### PR TITLE
waveform data was only getting computed for part of an audio file, not the entire file

### DIFF
--- a/EZAudio/EZAudioFile.m
+++ b/EZAudio/EZAudioFile.m
@@ -235,7 +235,7 @@
     for( int i = 0; i < _waveformTotalBuffers; i++ ){
       
       // Take a snapshot of each buffer through the audio file to form the waveform
-      AudioBufferList *bufferList = [EZAudio audioBufferListWithNumberOfFrames:1024
+      AudioBufferList *bufferList = [EZAudio audioBufferListWithNumberOfFrames:_waveformFrameRate
                                                               numberOfChannels:_clientFormat.mChannelsPerFrame
                                                                    interleaved:YES];
       UInt32 bufferSize;


### PR DESCRIPTION
I may be wrong about the intended functionality of `getWaveformDataWithCompletionBlock`, but the code was only computing the waveform for part of an audio file. I changed the hardcoded frame count 1024 to the actual frame count `_waveformFramerate`.
