### PR TITLE
Fix crash on very short wave files by setting min frames to at least 1

### DIFF
--- a/EZAudio/EZAudioFile.m
+++ b/EZAudio/EZAudioFile.m
@@ -312,11 +312,13 @@
 #pragma mark - Helpers
 -(UInt32)minBuffersWithFrameRate:(UInt32)frameRate {
   frameRate = frameRate > 0 ? frameRate : 1;
-  return (UInt32) _totalFrames / frameRate + 1;
+  UInt32 val = (UInt32) _totalFrames / frameRate + 1;
+  return MAX(1, val);
 }
 
 -(UInt32)recommendedDrawingFrameRate {
-  return (UInt32) _totalFrames / _waveformResolution - 1;
+  UInt32 val = (UInt32) _totalFrames / _waveformResolution - 1;
+  return MAX(1, val);
 }
 
 #pragma mark - Cleanup


### PR DESCRIPTION
This fixes a crash when the wave file is very short and the requested frame size would get set to 0 due to integer division. I just put in a MAX(1, val) in two places that seems to have resolved the problem.
