### PR TITLE
Set EAGLContext.currentContext before each set of GL calls.

### DIFF
--- a/EZAudio/EZAudioPlotGLKViewController.m
+++ b/EZAudio/EZAudioPlotGLKViewController.m
@@ -220,6 +220,9 @@
   // Make sure the update render loop is active
   if( self.paused ) self.paused = NO;
   
+  // Make sure we are updating the buffers on the correct gl context.
+  EAGLContext.currentContext = self.context;
+  
   // Draw based on plot type
   switch(_plotType) {
     case EZPlotTypeBuffer:
@@ -351,6 +354,9 @@
 
 #pragma mark - Drawing
 -(void)glkView:(GLKView *)view drawInRect:(CGRect)rect {
+ 
+  EAGLContext.currentContext = self.context;
+ 
   // Clear the context
   glClear(GL_COLOR_BUFFER_BIT);
   


### PR DESCRIPTION
Hi, I'm very pleased with EZAudio, and I've been using it a bunch! Here's a screenshot of it in action:
http://kortham.net/temp/upshot_7VBFx4Jj.png

I recently moved from EZAudioPlot (core graphics) to EZAudioPlotGL, and found a bug. It crashed, usually on glDrawArrays when I display more than one EZAudioPlotGL at once.  This seems to be due to incorrect settings on the GL currentContext. (Perhaps the glBufferData was submit all on the same context and then each glDrawArrays was called for different contexts, I'm not sure).

Anyway, the attached pull request fixed the issue for me.

I did first make sure that all of this was happening in one thread- that does seem to be the case. 

In my situation, I've got the EZAudioPlotGLs in a UITableView, one in each cell. I'm not sure if that messes with the order of the ViewDidLoads/ glkView:drawInRect / etc. I didn't try to see if this problem occurs when two EZAudioPlotGLs are in the same simple view container.

Thanks, I really love the project! Keep up the great work!
