### PR TITLE
Uncommented lines of code that were causing the AudioPlot to have a gap ...

### DIFF
--- a/EZAudio/EZAudioPlot.m
+++ b/EZAudio/EZAudioPlot.m
@@ -211,7 +211,7 @@
     
     if(plotLength > 0) {
       
-//      plotData[plotLength-1] = CGPointMake(plotLength-1,0.0f);
+      plotData[plotLength-1] = CGPointMake(plotLength-1,0.0f);
       
       CGMutablePathRef halfPath = CGPathCreateMutable();
       CGPathAddLines(halfPath,


### PR DESCRIPTION
...when reading from the buffer

Before:
![screen shot 2014-06-29 at 11 06 46 am](https://cloud.githubusercontent.com/assets/627123/3423593/32c6b220-ff9f-11e3-9f10-08ecf5547264.png)

After:
![screen shot 2014-06-29 at 11 07 15 am](https://cloud.githubusercontent.com/assets/627123/3423594/3bf4b7a2-ff9f-11e3-8027-52ccc8560823.png)
