### PR TITLE
Fixed iOS 7 Deprecation Warnings.

### DIFF
--- a/EZAudio/EZMicrophone.m
+++ b/EZAudio/EZMicrophone.m
@@ -457,11 +457,7 @@ static OSStatus inputCallback(void                          *inRefCon,
     // Use approximations for simulator and pull from real device if connected
     #if !(TARGET_IPHONE_SIMULATOR)
     // Sample Rate
-    UInt32 propSize = sizeof(Float64);
-    [EZAudio checkResult:AudioSessionGetProperty(kAudioSessionProperty_CurrentHardwareSampleRate,
-                                                 &propSize,
-                                                 &hardwareSampleRate)
-               operation:"Could not get hardware sample rate from device"];
+    hardwareSampleRate = [[AVAudioSession sharedInstance] sampleRate];
     #endif
   #elif TARGET_OS_MAC
     hardwareSampleRate = inputScopeSampleRate;
@@ -475,17 +471,14 @@ static OSStatus inputCallback(void                          *inRefCon,
   #if TARGET_OS_IPHONE
   // Use approximations for simulator and pull from real device if connected
     #if !(TARGET_IPHONE_SIMULATOR)
-      UInt32 propSize = sizeof(Float32);
-      [EZAudio checkResult:AudioSessionSetProperty(kAudioSessionProperty_PreferredHardwareIOBufferDuration,
-                                                 propSize,
-                                                 &bufferDuration)
-               operation:"Couldn't set the preferred buffer duration from device"];
-      // Buffer Size
-      propSize = sizeof(bufferDuration);
-      [EZAudio checkResult:AudioSessionGetProperty(kAudioSessionProperty_CurrentHardwareIOBufferDuration,
-                                                 &propSize,
-                                                 &bufferDuration)
-               operation:"Could not get preferred buffer size from device"];
+        NSError *err;
+        [[AVAudioSession sharedInstance] setPreferredIOBufferDuration:bufferDuration error:&err];
+        if (err) {
+            NSLog(@"Error setting preferredIOBufferDuration for audio session: %@", err.localizedDescription);
+        }
+        
+        // Buffer Size
+        bufferDuration = [[AVAudioSession sharedInstance] IOBufferDuration];
     #endif
   #elif TARGET_OS_MAC
   

--- a/EZAudio/EZOutput.m
+++ b/EZAudio/EZOutput.m
@@ -226,11 +226,7 @@ static OSStatus OutputRenderCallback(void                        *inRefCon,
   // Get the hardware sample rate
   Float64 hardwareSampleRate = 44100;
 #if !(TARGET_IPHONE_SIMULATOR)
-  UInt32 propSize = sizeof(hardwareSampleRate);
-  [EZAudio checkResult:AudioSessionGetProperty(kAudioSessionProperty_CurrentHardwareSampleRate,
-                                               &propSize,
-                                               &hardwareSampleRate)
-             operation:"Could not get hardware sample rate"];
+  hardwareSampleRate = [[AVAudioSession sharedInstance] sampleRate];
 #endif
   
   // Setup an ASBD in canonical format by default


### PR DESCRIPTION
Replaced AudioSessionSetProperty and AudioSessionGetProperty, which
were deprecated in iOS 7. (For some reason, the warnings only showed up for me if I ran the project on a physical device, but this seems to fix them.)
