### PR TITLE
Don't override default output/input in EZAudioPlayer

### DIFF
--- a/EZAudio/EZAudioPlayer.m
+++ b/EZAudio/EZAudioPlayer.m
@@ -127,13 +127,8 @@
   if( err ){
     NSLog(@"There was an error creating the audio session");
   }
-  [audioSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:NULL];
-  if( err ){
-    NSLog(@"There was an error sending the audio to the speakers");
-  }
 #elif TARGET_OS_MAC
 #endif
-  
 }
 
 #pragma mark - Getters


### PR DESCRIPTION
By default when the EZAudioPlayer is initialized, it overrides the default output and input for some unknown reason. This doesn't really play nice with most apps.

For example, with headphones plugged in, EZAudio will still output to speakers!

This pull request fixes this.