### PR TITLE
don't turn on PlayAndRecord AVAudioSession until we need it

### DIFF
--- a/EZAudio/EZAudioPlayer.m
+++ b/EZAudio/EZAudioPlayer.m
@@ -115,15 +115,15 @@
 
 #pragma mark - Private Configuration
 -(void)_configureAudioPlayer {
-  
+
   // Defaults
   self.output = [EZOutput sharedOutput];
-  
+
 #if TARGET_OS_IPHONE
   // Configure the AVSession
   AVAudioSession *audioSession = [AVAudioSession sharedInstance];
   NSError *err = NULL;
-  [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord error:&err];
+  [audioSession setCategory:AVAudioSessionCategoryPlayback error:&err];
   if( err ){
     NSLog(@"There was an error creating the audio session");
   }
@@ -191,7 +191,7 @@
   _eof       = NO;
   _audioFile = [EZAudioFile audioFileWithURL:audioFile.url andDelegate:self];
   NSAssert(_output,@"No output was found, this should by default be the EZOutput shared instance");
-  [_output setAudioStreamBasicDescription:self.audioFile.clientFormat];    
+  [_output setAudioStreamBasicDescription:self.audioFile.clientFormat];
 }
 
 -(void)setOutput:(EZOutput*)output {


### PR DESCRIPTION
Today once the EZAudioPlayer is started, it asks for AVAudioSessionCategoryPlayAndRecord which disables the main speakers at the bottom of the iPhone (since those can't be used together with the mic) and also (AFAICS) asks for mic permission.

In this patch I am upgrading the session when the mic is initialized instead, and then when playback is stopped we go back to normal playback-only etc.