### PR TITLE
Renamed AEFloatConverter stuff to resolve conflicts with other pod

### DIFF
--- a/EZAudio/EZAudio.h
+++ b/EZAudio/EZAudio.h
@@ -26,7 +26,7 @@
 #import <Foundation/Foundation.h>
 
 #pragma mark - 3rd Party Utilties
-#import "AEFloatConverter.h"
+#import "EZ_AEFloatConverter.h"
 #import "TPCircularBuffer.h"
 
 #pragma mark - Core Components

--- a/EZAudio/EZAudioFile.m
+++ b/EZAudio/EZAudioFile.m
@@ -177,7 +177,7 @@
                           updatedPosition:_frameIndex];
       }
       if( [self.audioFileDelegate respondsToSelector:@selector(audioFile:readAudio:withBufferSize:withNumberOfChannels:)] ){
-        AEFloatConverterToFloat(_floatConverter,audioBufferList,_floatBuffers,frames);
+        EZ_AEFloatConverterToFloat(_floatConverter,audioBufferList,_floatBuffers,frames);
         [self.audioFileDelegate audioFile:self
                                 readAudio:_floatBuffers
                            withBufferSize:frames

--- a/EZAudio/EZAudioFile.m
+++ b/EZAudio/EZAudioFile.m
@@ -36,7 +36,7 @@
   AudioStreamBasicDescription _clientFormat;
   AudioStreamBasicDescription _fileFormat;
   float                       **_floatBuffers;
-  AEFloatConverter            *_floatConverter;
+  EZ_AEFloatConverter            *_floatConverter;
   SInt64                      _frameIndex;
   CFURLRef                    _sourceURL;
   Float32                     _totalDuration;
@@ -140,7 +140,7 @@
              operation:"Couldn't set client data format on input ext file"];
   
   // Allocate the float buffers
-  _floatConverter = [[AEFloatConverter alloc] initWithSourceFormat:_clientFormat];
+  _floatConverter = [[EZ_AEFloatConverter alloc] initWithSourceFormat:_clientFormat];
   size_t sizeToAllocate = sizeof(float*) * _clientFormat.mChannelsPerFrame;
   sizeToAllocate = MAX(8, sizeToAllocate);
   _floatBuffers   = (float**)malloc( sizeToAllocate );

--- a/EZAudio/EZMicrophone.h
+++ b/EZAudio/EZMicrophone.h
@@ -25,7 +25,7 @@
 
 #import  <Foundation/Foundation.h>
 #import  <AudioToolbox/AudioToolbox.h>
-#import  "AEFloatConverter.h"
+#import  "EZ_AEFloatConverter.h"
 #import  "TargetConditionals.h"
 
 @class EZAudio;

--- a/EZAudio/EZMicrophone.m
+++ b/EZAudio/EZMicrophone.m
@@ -51,7 +51,7 @@ static const UInt32 kEZAudioMicrophoneEnableFlag  = 1;
   BOOL _isFetching;
   
   /// Stream Description
-  AEFloatConverter            *converter;
+  EZ_AEFloatConverter            *converter;
   AudioStreamBasicDescription streamFormat;
   
   /// Audio Graph and Input/Output Units
@@ -558,7 +558,7 @@ static OSStatus inputCallback(void                          *inRefCon,
 #pragma mark - Float Converter Initialization
 -(void)_configureFloatConverterWithFrameSize:(UInt32)bufferFrameSize {
   UInt32 bufferSizeBytes = bufferFrameSize * streamFormat.mBytesPerFrame;
-  converter              = [[AEFloatConverter alloc] initWithSourceFormat:streamFormat];
+  converter              = [[EZ_AEFloatConverter alloc] initWithSourceFormat:streamFormat];
   floatBuffers           = (float**)malloc(sizeof(float*)*streamFormat.mChannelsPerFrame);
   assert(floatBuffers);
   for ( int i=0; i<streamFormat.mChannelsPerFrame; i++ ) {

--- a/EZAudio/EZMicrophone.m
+++ b/EZAudio/EZMicrophone.m
@@ -100,7 +100,7 @@ static OSStatus inputCallback(void                          *inRefCon,
     if( microphone.microphoneDelegate ){
       // THIS IS NOT OCCURING ON THE MAIN THREAD
       if( [microphone.microphoneDelegate respondsToSelector:@selector(microphone:hasAudioReceived:withBufferSize:withNumberOfChannels:)] ){
-        AEFloatConverterToFloat(microphone->converter,
+        EZ_AEFloatConverterToFloat(microphone->converter,
                                 microphone->microphoneInputBuffer,
                                 microphone->floatBuffers,
                                 inNumberFrames);

--- a/EZAudio/EZ_AEFloatConverter.h
+++ b/EZAudio/EZ_AEFloatConverter.h
@@ -59,7 +59,7 @@ extern "C" {
  * @param frames            The number of frames to convert.
  * @return YES on success; NO on failure
  */
-BOOL AEFloatConverterToFloat(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer, float * const * targetBuffers, UInt32 frames);
+BOOL EZ_AEFloatConverterToFloat(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer, float * const * targetBuffers, UInt32 frames);
 
 /*!
  * Convert audio to floating-point, in a buffer list
@@ -74,7 +74,7 @@ BOOL AEFloatConverterToFloat(EZ_AEFloatConverter* converter, AudioBufferList *so
  * @param frames            The number of frames to convert.
  * @return YES on success; NO on failure
  */
-BOOL AEFloatConverterToFloatBufferList(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer,  AudioBufferList *targetBuffer, UInt32 frames);
+BOOL EZ_AEFloatConverterToFloatBufferList(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer,  AudioBufferList *targetBuffer, UInt32 frames);
 
 /*!
  * Convert audio from floating-point
@@ -90,7 +90,7 @@ BOOL AEFloatConverterToFloatBufferList(EZ_AEFloatConverter* converter, AudioBuff
  * @param frames            The number of frames to convert.
  * @return YES on success; NO on failure
  */
-BOOL AEFloatConverterFromFloat(EZ_AEFloatConverter* converter, float * const * sourceBuffers, AudioBufferList *targetBuffer, UInt32 frames);
+BOOL EZ_AEFloatConverterFromFloat(EZ_AEFloatConverter* converter, float * const * sourceBuffers, AudioBufferList *targetBuffer, UInt32 frames);
 
 /*!
  * Convert audio from floating-point, in a buffer list
@@ -105,7 +105,7 @@ BOOL AEFloatConverterFromFloat(EZ_AEFloatConverter* converter, float * const * s
  * @param frames            The number of frames to convert.
  * @return YES on success; NO on failure
  */
-BOOL AEFloatConverterFromFloatBufferList(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer, AudioBufferList *targetBuffer, UInt32 frames);
+BOOL EZ_AEFloatConverterFromFloatBufferList(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer, AudioBufferList *targetBuffer, UInt32 frames);
 
 /*!
  * The AudioStreamBasicDescription representing the converted floating-point format

--- a/EZAudio/EZ_AEFloatConverter.h
+++ b/EZAudio/EZ_AEFloatConverter.h
@@ -36,7 +36,7 @@ extern "C" {
  *  Use this class to easily convert arbitrary audio formats to floating point
  *  for use with utilities like the Accelerate framework.
  */
-@interface AEFloatConverter : NSObject
+@interface EZ_AEFloatConverter : NSObject
 
 /*!
  * Initialize
@@ -59,7 +59,7 @@ extern "C" {
  * @param frames            The number of frames to convert.
  * @return YES on success; NO on failure
  */
-BOOL AEFloatConverterToFloat(AEFloatConverter* converter, AudioBufferList *sourceBuffer, float * const * targetBuffers, UInt32 frames);
+BOOL AEFloatConverterToFloat(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer, float * const * targetBuffers, UInt32 frames);
 
 /*!
  * Convert audio to floating-point, in a buffer list
@@ -74,7 +74,7 @@ BOOL AEFloatConverterToFloat(AEFloatConverter* converter, AudioBufferList *sourc
  * @param frames            The number of frames to convert.
  * @return YES on success; NO on failure
  */
-BOOL AEFloatConverterToFloatBufferList(AEFloatConverter* converter, AudioBufferList *sourceBuffer,  AudioBufferList *targetBuffer, UInt32 frames);
+BOOL AEFloatConverterToFloatBufferList(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer,  AudioBufferList *targetBuffer, UInt32 frames);
 
 /*!
  * Convert audio from floating-point
@@ -90,7 +90,7 @@ BOOL AEFloatConverterToFloatBufferList(AEFloatConverter* converter, AudioBufferL
  * @param frames            The number of frames to convert.
  * @return YES on success; NO on failure
  */
-BOOL AEFloatConverterFromFloat(AEFloatConverter* converter, float * const * sourceBuffers, AudioBufferList *targetBuffer, UInt32 frames);
+BOOL AEFloatConverterFromFloat(EZ_AEFloatConverter* converter, float * const * sourceBuffers, AudioBufferList *targetBuffer, UInt32 frames);
 
 /*!
  * Convert audio from floating-point, in a buffer list
@@ -105,7 +105,7 @@ BOOL AEFloatConverterFromFloat(AEFloatConverter* converter, float * const * sour
  * @param frames            The number of frames to convert.
  * @return YES on success; NO on failure
  */
-BOOL AEFloatConverterFromFloatBufferList(AEFloatConverter* converter, AudioBufferList *sourceBuffer, AudioBufferList *targetBuffer, UInt32 frames);
+BOOL AEFloatConverterFromFloatBufferList(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer, AudioBufferList *targetBuffer, UInt32 frames);
 
 /*!
  * The AudioStreamBasicDescription representing the converted floating-point format

--- a/EZAudio/EZ_AEFloatConverter.m
+++ b/EZAudio/EZ_AEFloatConverter.m
@@ -93,7 +93,7 @@ static OSStatus complexInputDataProc(AudioConverterRef             inAudioConver
 }
 
 
-BOOL AEFloatConverterToFloat(EZ_AEFloatConverter* THIS, AudioBufferList *sourceBuffer, float * const * targetBuffers, UInt32 frames) {
+BOOL EZ_AEFloatConverterToFloat(EZ_AEFloatConverter* THIS, AudioBufferList *sourceBuffer, float * const * targetBuffers, UInt32 frames) {
     if ( frames == 0 ) return YES;
     
     if ( THIS->_toFloatConverter ) {
@@ -131,17 +131,17 @@ BOOL AEFloatConverterToFloat(EZ_AEFloatConverter* THIS, AudioBufferList *sourceB
     return YES;
 }
 
-BOOL AEFloatConverterToFloatBufferList(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer,  AudioBufferList *targetBuffer, UInt32 frames) {
+BOOL EZ_AEFloatConverterToFloatBufferList(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer,  AudioBufferList *targetBuffer, UInt32 frames) {
     assert(targetBuffer->mNumberBuffers == converter->_floatAudioDescription.mChannelsPerFrame);
     
     float *targetBuffers[targetBuffer->mNumberBuffers];
     for ( int i=0; i<targetBuffer->mNumberBuffers; i++ ) {
         targetBuffers[i] = (float*)targetBuffer->mBuffers[i].mData;
     }
-    return AEFloatConverterToFloat(converter, sourceBuffer, targetBuffers, frames);
+    return EZ_AEFloatConverterToFloat(converter, sourceBuffer, targetBuffers, frames);
 }
 
-BOOL AEFloatConverterFromFloat(EZ_AEFloatConverter* THIS, float * const * sourceBuffers, AudioBufferList *targetBuffer, UInt32 frames) {
+BOOL EZ_AEFloatConverterFromFloat(EZ_AEFloatConverter* THIS, float * const * sourceBuffers, AudioBufferList *targetBuffer, UInt32 frames) {
     if ( frames == 0 ) return YES;
     
     if ( THIS->_fromFloatConverter ) {
@@ -178,14 +178,14 @@ BOOL AEFloatConverterFromFloat(EZ_AEFloatConverter* THIS, float * const * source
     return YES;
 }
 
-BOOL AEFloatConverterFromFloatBufferList(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer, AudioBufferList *targetBuffer, UInt32 frames) {
+BOOL EZ_AEFloatConverterFromFloatBufferList(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer, AudioBufferList *targetBuffer, UInt32 frames) {
     assert(sourceBuffer->mNumberBuffers == converter->_floatAudioDescription.mChannelsPerFrame);
     
     float *sourceBuffers[sourceBuffer->mNumberBuffers];
     for ( int i=0; i<sourceBuffer->mNumberBuffers; i++ ) {
         sourceBuffers[i] = (float*)sourceBuffer->mBuffers[i].mData;
     }
-    return AEFloatConverterFromFloat(converter, sourceBuffers, targetBuffer, frames);
+    return EZ_AEFloatConverterFromFloat(converter, sourceBuffers, targetBuffer, frames);
 }
 
 static OSStatus complexInputDataProc(AudioConverterRef             inAudioConverter,

--- a/EZAudio/EZ_AEFloatConverter.m
+++ b/EZAudio/EZ_AEFloatConverter.m
@@ -23,7 +23,7 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
-#import "AEFloatConverter.h"
+#import "EZ_AEFloatConverter.h"
 
 #define checkResult(result,operation) (_checkResult((result),(operation),strrchr(__FILE__, '/')+1,__LINE__))
 static inline BOOL _checkResult(OSStatus result, const char *operation, const char* file, int line) {
@@ -40,7 +40,7 @@ struct complexInputDataProc_t {
     AudioBufferList *sourceBuffer;
 };
 
-@interface AEFloatConverter () {
+@interface EZ_AEFloatConverter () {
     AudioStreamBasicDescription _sourceAudioDescription;
     AudioStreamBasicDescription _floatAudioDescription;
     AudioConverterRef           _toFloatConverter;
@@ -55,7 +55,7 @@ static OSStatus complexInputDataProc(AudioConverterRef             inAudioConver
                                      void                          *inUserData);
 @end
 
-@implementation AEFloatConverter
+@implementation EZ_AEFloatConverter
 @synthesize sourceFormat = _sourceAudioDescription;
 
 -(id)initWithSourceFormat:(AudioStreamBasicDescription)sourceFormat {
@@ -93,7 +93,7 @@ static OSStatus complexInputDataProc(AudioConverterRef             inAudioConver
 }
 
 
-BOOL AEFloatConverterToFloat(AEFloatConverter* THIS, AudioBufferList *sourceBuffer, float * const * targetBuffers, UInt32 frames) {
+BOOL AEFloatConverterToFloat(EZ_AEFloatConverter* THIS, AudioBufferList *sourceBuffer, float * const * targetBuffers, UInt32 frames) {
     if ( frames == 0 ) return YES;
     
     if ( THIS->_toFloatConverter ) {
@@ -131,7 +131,7 @@ BOOL AEFloatConverterToFloat(AEFloatConverter* THIS, AudioBufferList *sourceBuff
     return YES;
 }
 
-BOOL AEFloatConverterToFloatBufferList(AEFloatConverter* converter, AudioBufferList *sourceBuffer,  AudioBufferList *targetBuffer, UInt32 frames) {
+BOOL AEFloatConverterToFloatBufferList(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer,  AudioBufferList *targetBuffer, UInt32 frames) {
     assert(targetBuffer->mNumberBuffers == converter->_floatAudioDescription.mChannelsPerFrame);
     
     float *targetBuffers[targetBuffer->mNumberBuffers];
@@ -141,7 +141,7 @@ BOOL AEFloatConverterToFloatBufferList(AEFloatConverter* converter, AudioBufferL
     return AEFloatConverterToFloat(converter, sourceBuffer, targetBuffers, frames);
 }
 
-BOOL AEFloatConverterFromFloat(AEFloatConverter* THIS, float * const * sourceBuffers, AudioBufferList *targetBuffer, UInt32 frames) {
+BOOL AEFloatConverterFromFloat(EZ_AEFloatConverter* THIS, float * const * sourceBuffers, AudioBufferList *targetBuffer, UInt32 frames) {
     if ( frames == 0 ) return YES;
     
     if ( THIS->_fromFloatConverter ) {
@@ -178,7 +178,7 @@ BOOL AEFloatConverterFromFloat(AEFloatConverter* THIS, float * const * sourceBuf
     return YES;
 }
 
-BOOL AEFloatConverterFromFloatBufferList(AEFloatConverter* converter, AudioBufferList *sourceBuffer, AudioBufferList *targetBuffer, UInt32 frames) {
+BOOL AEFloatConverterFromFloatBufferList(EZ_AEFloatConverter* converter, AudioBufferList *sourceBuffer, AudioBufferList *targetBuffer, UInt32 frames) {
     assert(sourceBuffer->mNumberBuffers == converter->_floatAudioDescription.mChannelsPerFrame);
     
     float *sourceBuffers[sourceBuffer->mNumberBuffers];

--- a/EZAudioExamples/OSX/EZAudioCoreGraphicsWaveformExample/EZAudioCoreGraphicsWaveformExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/OSX/EZAudioCoreGraphicsWaveformExample/EZAudioCoreGraphicsWaveformExample.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 /* Begin PBXBuildFile section */
 		94056D88185B97E300EB94BA /* CoreGraphicsWaveformViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 94056D86185B97E300EB94BA /* CoreGraphicsWaveformViewController.m */; };
 		94056D89185B97E300EB94BA /* CoreGraphicsWaveformViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 94056D87185B97E300EB94BA /* CoreGraphicsWaveformViewController.xib */; };
-		9417A6F01867DC8300D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A6D81867DC8300D9D37B /* AEFloatConverter.m */; };
 		9417A6F11867DC8300D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A6DA1867DC8300D9D37B /* EZAudio.m */; };
 		9417A6F21867DC8300D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A6DC1867DC8300D9D37B /* EZAudioFile.m */; };
 		9417A6F31867DC8300D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A6DE1867DC8300D9D37B /* EZAudioPlot.m */; };
@@ -53,6 +52,7 @@
 		94373084185B936B00F315F0 /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94373083185B936B00F315F0 /* GLKit.framework */; };
 		94373086185B937100F315F0 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94373085185B937100F315F0 /* OpenGL.framework */; };
 		94373088185B937E00F315F0 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94373087185B937E00F315F0 /* QuartzCore.framework */; };
+		F1C7DEB01A52447A005F7001 /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C7DEAF1A52447A005F7001 /* EZ_AEFloatConverter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,8 +69,6 @@
 		94056D85185B97E300EB94BA /* CoreGraphicsWaveformViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = CoreGraphicsWaveformViewController.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		94056D86185B97E300EB94BA /* CoreGraphicsWaveformViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CoreGraphicsWaveformViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		94056D87185B97E300EB94BA /* CoreGraphicsWaveformViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CoreGraphicsWaveformViewController.xib; sourceTree = "<group>"; };
-		9417A6D71867DC8300D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A6D81867DC8300D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A6D91867DC8300D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A6DA1867DC8300D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A6DB1867DC8300D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -118,6 +116,8 @@
 		94373083185B936B00F315F0 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
 		94373085185B937100F315F0 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
 		94373087185B937E00F315F0 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		F1C7DEAE1A52447A005F7001 /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		F1C7DEAF1A52447A005F7001 /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -150,8 +150,8 @@
 		9417A6D61867DC8300D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A6D71867DC8300D9D37B /* AEFloatConverter.h */,
-				9417A6D81867DC8300D9D37B /* AEFloatConverter.m */,
+				F1C7DEAE1A52447A005F7001 /* EZ_AEFloatConverter.h */,
+				F1C7DEAF1A52447A005F7001 /* EZ_AEFloatConverter.m */,
 				9417A6D91867DC8300D9D37B /* EZAudio.h */,
 				9417A6DA1867DC8300D9D37B /* EZAudio.m */,
 				9417A6DB1867DC8300D9D37B /* EZAudioFile.h */,
@@ -396,11 +396,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1C7DEB01A52447A005F7001 /* EZ_AEFloatConverter.m in Sources */,
 				9417A6FA1867DC8300D9D37B /* TPCircularBuffer.c in Sources */,
 				9417A6F71867DC8300D9D37B /* EZOutput.m in Sources */,
 				9417A6F51867DC8300D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
 				94056D88185B97E300EB94BA /* CoreGraphicsWaveformViewController.m in Sources */,
-				9417A6F01867DC8300D9D37B /* AEFloatConverter.m in Sources */,
 				94373038185B931C00F315F0 /* AppDelegate.m in Sources */,
 				9417A6F31867DC8300D9D37B /* EZAudioPlot.m in Sources */,
 				9417A6F21867DC8300D9D37B /* EZAudioFile.m in Sources */,
@@ -652,6 +652,7 @@
 				94F8DF4C18C84204005C4CBD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/EZAudioExamples/OSX/EZAudioFFTExample/EZAudioFFTExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/OSX/EZAudioFFTExample/EZAudioFFTExample.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		9417A9171871492100D9D37B /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A8F61871492000D9D37B /* Cocoa.framework */; };
 		9417A91F1871492100D9D37B /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9417A91D1871492100D9D37B /* InfoPlist.strings */; };
 		9417A9211871492100D9D37B /* EZAudioFFTExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A9201871492100D9D37B /* EZAudioFFTExampleTests.m */; };
-		9417A9441871493900D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A92C1871493900D9D37B /* AEFloatConverter.m */; };
 		9417A9451871493900D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A92E1871493900D9D37B /* EZAudio.m */; };
 		9417A9461871493900D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A9301871493900D9D37B /* EZAudioFile.m */; };
 		9417A9471871493900D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A9321871493900D9D37B /* EZAudioPlot.m */; };
@@ -40,6 +39,7 @@
 		9417A95E18714A2A00D9D37B /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A95D18714A2A00D9D37B /* Accelerate.framework */; };
 		9417A9D61872130200D9D37B /* FFTViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A9D41872130200D9D37B /* FFTViewController.m */; };
 		9417A9D71872130200D9D37B /* FFTViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9417A9D51872130200D9D37B /* FFTViewController.xib */; };
+		F1C7DEC21A5244BD005F7001 /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C7DEC11A5244BD005F7001 /* EZ_AEFloatConverter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,8 +72,6 @@
 		9417A91C1871492100D9D37B /* EZAudioFFTExampleTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "EZAudioFFTExampleTests-Info.plist"; sourceTree = "<group>"; };
 		9417A91E1871492100D9D37B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		9417A9201871492100D9D37B /* EZAudioFFTExampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EZAudioFFTExampleTests.m; sourceTree = "<group>"; };
-		9417A92B1871493900D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A92C1871493900D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A92D1871493900D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A92E1871493900D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A92F1871493900D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -106,6 +104,8 @@
 		9417A9D31872130200D9D37B /* FFTViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FFTViewController.h; sourceTree = "<group>"; };
 		9417A9D41872130200D9D37B /* FFTViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FFTViewController.m; sourceTree = "<group>"; };
 		9417A9D51872130200D9D37B /* FFTViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FFTViewController.xib; sourceTree = "<group>"; };
+		F1C7DEC01A5244BD005F7001 /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		F1C7DEC11A5244BD005F7001 /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -231,8 +231,8 @@
 		9417A92A1871493900D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A92B1871493900D9D37B /* AEFloatConverter.h */,
-				9417A92C1871493900D9D37B /* AEFloatConverter.m */,
+				F1C7DEC01A5244BD005F7001 /* EZ_AEFloatConverter.h */,
+				F1C7DEC11A5244BD005F7001 /* EZ_AEFloatConverter.m */,
 				9417A92D1871493900D9D37B /* EZAudio.h */,
 				9417A92E1871493900D9D37B /* EZAudio.m */,
 				9417A92F1871493900D9D37B /* EZAudioFile.h */,
@@ -369,11 +369,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1C7DEC21A5244BD005F7001 /* EZ_AEFloatConverter.m in Sources */,
 				9417A94D1871493900D9D37B /* EZRecorder.m in Sources */,
 				9417A9471871493900D9D37B /* EZAudioPlot.m in Sources */,
 				9417A94C1871493900D9D37B /* EZPlot.m in Sources */,
 				9417A9D61872130200D9D37B /* FFTViewController.m in Sources */,
-				9417A9441871493900D9D37B /* AEFloatConverter.m in Sources */,
 				9417A94A1871493900D9D37B /* EZMicrophone.m in Sources */,
 				9417A94B1871493900D9D37B /* EZOutput.m in Sources */,
 				9417A9451871493900D9D37B /* EZAudio.m in Sources */,

--- a/EZAudioExamples/OSX/EZAudioOpenGLWaveformExample/EZAudioOpenGLWaveformExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/OSX/EZAudioOpenGLWaveformExample/EZAudioOpenGLWaveformExample.xcodeproj/project.pbxproj
@@ -26,7 +26,6 @@
 		94056DD8185BB0F400EB94BA /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94056DD5185BB0F400EB94BA /* AudioToolbox.framework */; };
 		94056DD9185BB0F400EB94BA /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94056DD6185BB0F400EB94BA /* AudioUnit.framework */; };
 		94056DDA185BB0F400EB94BA /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94056DD7185BB0F400EB94BA /* CoreAudio.framework */; };
-		9417A7171867DD2800D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A6FF1867DD2800D9D37B /* AEFloatConverter.m */; };
 		9417A7181867DD2800D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7011867DD2800D9D37B /* EZAudio.m */; };
 		9417A7191867DD2800D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7031867DD2800D9D37B /* EZAudioFile.m */; };
 		9417A71A1867DD2800D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7051867DD2800D9D37B /* EZAudioPlot.m */; };
@@ -39,6 +38,7 @@
 		9417A7211867DD2800D9D37B /* TPCircularBuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7121867DD2800D9D37B /* TPCircularBuffer.c */; };
 		9417A7221867DD2800D9D37B /* CHANGELOG in Resources */ = {isa = PBXBuildFile; fileRef = 9417A7151867DD2800D9D37B /* CHANGELOG */; };
 		9417A7231867DD2800D9D37B /* VERSION in Resources */ = {isa = PBXBuildFile; fileRef = 9417A7161867DD2800D9D37B /* VERSION */; };
+		F1C7DEB31A524485005F7001 /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C7DEB21A524485005F7001 /* EZ_AEFloatConverter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,8 +80,6 @@
 		94056DD5185BB0F400EB94BA /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		94056DD6185BB0F400EB94BA /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
 		94056DD7185BB0F400EB94BA /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
-		9417A6FE1867DD2800D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A6FF1867DD2800D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A7001867DD2800D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A7011867DD2800D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A7021867DD2800D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -104,6 +102,8 @@
 		9417A7131867DD2800D9D37B /* TPCircularBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPCircularBuffer.h; sourceTree = "<group>"; };
 		9417A7151867DD2800D9D37B /* CHANGELOG */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CHANGELOG; sourceTree = "<group>"; };
 		9417A7161867DD2800D9D37B /* VERSION */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = VERSION; sourceTree = "<group>"; };
+		F1C7DEB11A524485005F7001 /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		F1C7DEB21A524485005F7001 /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -227,8 +227,8 @@
 		9417A6FD1867DD2800D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A6FE1867DD2800D9D37B /* AEFloatConverter.h */,
-				9417A6FF1867DD2800D9D37B /* AEFloatConverter.m */,
+				F1C7DEB11A524485005F7001 /* EZ_AEFloatConverter.h */,
+				F1C7DEB21A524485005F7001 /* EZ_AEFloatConverter.m */,
 				9417A7001867DD2800D9D37B /* EZAudio.h */,
 				9417A7011867DD2800D9D37B /* EZAudio.m */,
 				9417A7021867DD2800D9D37B /* EZAudioFile.h */,
@@ -365,11 +365,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1C7DEB31A524485005F7001 /* EZ_AEFloatConverter.m in Sources */,
 				9417A7211867DD2800D9D37B /* TPCircularBuffer.c in Sources */,
 				9417A71E1867DD2800D9D37B /* EZOutput.m in Sources */,
 				9417A71C1867DD2800D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
 				94056DAA185BB0BC00EB94BA /* AppDelegate.m in Sources */,
-				9417A7171867DD2800D9D37B /* AEFloatConverter.m in Sources */,
 				94056DA3185BB0BC00EB94BA /* main.m in Sources */,
 				9417A71A1867DD2800D9D37B /* EZAudioPlot.m in Sources */,
 				9417A7191867DD2800D9D37B /* EZAudioFile.m in Sources */,

--- a/EZAudioExamples/OSX/EZAudioPassThroughExample/EZAudioPassThroughExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/OSX/EZAudioPassThroughExample/EZAudioPassThroughExample.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		9417A7B31867DD6600D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A79B1867DD6600D9D37B /* AEFloatConverter.m */; };
 		9417A7B41867DD6600D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A79D1867DD6600D9D37B /* EZAudio.m */; };
 		9417A7B51867DD6600D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A79F1867DD6600D9D37B /* EZAudioFile.m */; };
 		9417A7B61867DD6600D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7A11867DD6600D9D37B /* EZAudioPlot.m */; };
@@ -39,6 +38,7 @@
 		941D721D1864C4C0007D52D8 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 941D721C1864C4C0007D52D8 /* QuartzCore.framework */; };
 		941D72211864C4D7007D52D8 /* PassThroughViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 941D721F1864C4D7007D52D8 /* PassThroughViewController.m */; };
 		941D72221864C4D7007D52D8 /* PassThroughViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 941D72201864C4D7007D52D8 /* PassThroughViewController.xib */; };
+		F1C7DEBF1A5244B2005F7001 /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C7DEBE1A5244B2005F7001 /* EZ_AEFloatConverter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,8 +52,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		9417A79A1867DD6600D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A79B1867DD6600D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A79C1867DD6600D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A79D1867DD6600D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A79E1867DD6600D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -104,6 +102,8 @@
 		941D721E1864C4D7007D52D8 /* PassThroughViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PassThroughViewController.h; sourceTree = "<group>"; };
 		941D721F1864C4D7007D52D8 /* PassThroughViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PassThroughViewController.m; sourceTree = "<group>"; };
 		941D72201864C4D7007D52D8 /* PassThroughViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PassThroughViewController.xib; sourceTree = "<group>"; };
+		F1C7DEBD1A5244B2005F7001 /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		F1C7DEBE1A5244B2005F7001 /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,8 +136,8 @@
 		9417A7991867DD6600D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A79A1867DD6600D9D37B /* AEFloatConverter.h */,
-				9417A79B1867DD6600D9D37B /* AEFloatConverter.m */,
+				F1C7DEBD1A5244B2005F7001 /* EZ_AEFloatConverter.h */,
+				F1C7DEBE1A5244B2005F7001 /* EZ_AEFloatConverter.m */,
 				9417A79C1867DD6600D9D37B /* EZAudio.h */,
 				9417A79D1867DD6600D9D37B /* EZAudio.m */,
 				9417A79E1867DD6600D9D37B /* EZAudioFile.h */,
@@ -365,11 +365,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1C7DEBF1A5244B2005F7001 /* EZ_AEFloatConverter.m in Sources */,
 				9417A7BD1867DD6600D9D37B /* TPCircularBuffer.c in Sources */,
 				9417A7BA1867DD6600D9D37B /* EZOutput.m in Sources */,
 				9417A7B81867DD6600D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
 				941D72211864C4D7007D52D8 /* PassThroughViewController.m in Sources */,
-				9417A7B31867DD6600D9D37B /* AEFloatConverter.m in Sources */,
 				941D71CB1864C457007D52D8 /* AppDelegate.m in Sources */,
 				9417A7B61867DD6600D9D37B /* EZAudioPlot.m in Sources */,
 				9417A7B51867DD6600D9D37B /* EZAudioFile.m in Sources */,

--- a/EZAudioExamples/OSX/EZAudioPlayFileExample/EZAudioPlayFileExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/OSX/EZAudioPlayFileExample/EZAudioPlayFileExample.xcodeproj/project.pbxproj
@@ -27,7 +27,6 @@
 		94056F66185BDB4700EB94BA /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94056F63185BDB4700EB94BA /* AudioUnit.framework */; };
 		94056F67185BDB4700EB94BA /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94056F64185BDB4700EB94BA /* CoreAudio.framework */; };
 		9417A6D51865928C00D9D37B /* simple-drum-beat.wav in Resources */ = {isa = PBXBuildFile; fileRef = 9417A6D41865928C00D9D37B /* simple-drum-beat.wav */; };
-		9417A73E1867DD3400D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7261867DD3400D9D37B /* AEFloatConverter.m */; };
 		9417A73F1867DD3400D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7281867DD3400D9D37B /* EZAudio.m */; };
 		9417A7401867DD3400D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A72A1867DD3400D9D37B /* EZAudioFile.m */; };
 		9417A7411867DD3400D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A72C1867DD3400D9D37B /* EZAudioPlot.m */; };
@@ -40,6 +39,7 @@
 		9417A7481867DD3400D9D37B /* TPCircularBuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7391867DD3400D9D37B /* TPCircularBuffer.c */; };
 		9417A7491867DD3400D9D37B /* CHANGELOG in Resources */ = {isa = PBXBuildFile; fileRef = 9417A73C1867DD3400D9D37B /* CHANGELOG */; };
 		9417A74A1867DD3400D9D37B /* VERSION in Resources */ = {isa = PBXBuildFile; fileRef = 9417A73D1867DD3400D9D37B /* VERSION */; };
+		F1C7DEB61A524490005F7001 /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C7DEB51A524490005F7001 /* EZ_AEFloatConverter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,8 +82,6 @@
 		94056F63185BDB4700EB94BA /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
 		94056F64185BDB4700EB94BA /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		9417A6D41865928C00D9D37B /* simple-drum-beat.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = "simple-drum-beat.wav"; path = "../../../simple-drum-beat.wav"; sourceTree = "<group>"; };
-		9417A7251867DD3400D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A7261867DD3400D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A7271867DD3400D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A7281867DD3400D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A7291867DD3400D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -106,6 +104,8 @@
 		9417A73A1867DD3400D9D37B /* TPCircularBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPCircularBuffer.h; sourceTree = "<group>"; };
 		9417A73C1867DD3400D9D37B /* CHANGELOG */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CHANGELOG; sourceTree = "<group>"; };
 		9417A73D1867DD3400D9D37B /* VERSION */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = VERSION; sourceTree = "<group>"; };
+		F1C7DEB41A524490005F7001 /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		F1C7DEB51A524490005F7001 /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -230,8 +230,8 @@
 		9417A7241867DD3400D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A7251867DD3400D9D37B /* AEFloatConverter.h */,
-				9417A7261867DD3400D9D37B /* AEFloatConverter.m */,
+				F1C7DEB41A524490005F7001 /* EZ_AEFloatConverter.h */,
+				F1C7DEB51A524490005F7001 /* EZ_AEFloatConverter.m */,
 				9417A7271867DD3400D9D37B /* EZAudio.h */,
 				9417A7281867DD3400D9D37B /* EZAudio.m */,
 				9417A7291867DD3400D9D37B /* EZAudioFile.h */,
@@ -369,11 +369,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1C7DEB61A524490005F7001 /* EZ_AEFloatConverter.m in Sources */,
 				9417A7481867DD3400D9D37B /* TPCircularBuffer.c in Sources */,
 				9417A7451867DD3400D9D37B /* EZOutput.m in Sources */,
 				9417A7431867DD3400D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
 				94056F31185BD86D00EB94BA /* PlayFileViewController.m in Sources */,
-				9417A73E1867DD3400D9D37B /* AEFloatConverter.m in Sources */,
 				94056F0E185BD83400EB94BA /* AppDelegate.m in Sources */,
 				9417A7411867DD3400D9D37B /* EZAudioPlot.m in Sources */,
 				9417A7401867DD3400D9D37B /* EZAudioFile.m in Sources */,

--- a/EZAudioExamples/OSX/EZAudioRecordExample/EZAudioRecordExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/OSX/EZAudioRecordExample/EZAudioRecordExample.xcodeproj/project.pbxproj
@@ -26,7 +26,6 @@
 		94056E70185BB42100EB94BA /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94056E6F185BB42100EB94BA /* QuartzCore.framework */; };
 		94056E74185BB44200EB94BA /* RecordViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 94056E72185BB44200EB94BA /* RecordViewController.m */; };
 		94056E75185BB44200EB94BA /* RecordViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 94056E73185BB44200EB94BA /* RecordViewController.xib */; };
-		9417A7651867DD3F00D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A74D1867DD3F00D9D37B /* AEFloatConverter.m */; };
 		9417A7661867DD3F00D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A74F1867DD3F00D9D37B /* EZAudio.m */; };
 		9417A7671867DD3F00D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7511867DD3F00D9D37B /* EZAudioFile.m */; };
 		9417A7681867DD3F00D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7531867DD3F00D9D37B /* EZAudioPlot.m */; };
@@ -40,6 +39,7 @@
 		9417A7701867DD3F00D9D37B /* CHANGELOG in Resources */ = {isa = PBXBuildFile; fileRef = 9417A7631867DD3F00D9D37B /* CHANGELOG */; };
 		9417A7711867DD3F00D9D37B /* VERSION in Resources */ = {isa = PBXBuildFile; fileRef = 9417A7641867DD3F00D9D37B /* VERSION */; };
 		941D71AA186298AA007D52D8 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 941D71A9186298AA007D52D8 /* AVFoundation.framework */; };
+		F1C7DEB91A52449C005F7001 /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C7DEB81A52449C005F7001 /* EZ_AEFloatConverter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,8 +81,6 @@
 		94056E71185BB44200EB94BA /* RecordViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RecordViewController.h; sourceTree = "<group>"; };
 		94056E72185BB44200EB94BA /* RecordViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RecordViewController.m; sourceTree = "<group>"; };
 		94056E73185BB44200EB94BA /* RecordViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RecordViewController.xib; sourceTree = "<group>"; };
-		9417A74C1867DD3F00D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A74D1867DD3F00D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A74E1867DD3F00D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A74F1867DD3F00D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A7501867DD3F00D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -106,6 +104,8 @@
 		9417A7631867DD3F00D9D37B /* CHANGELOG */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CHANGELOG; sourceTree = "<group>"; };
 		9417A7641867DD3F00D9D37B /* VERSION */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = VERSION; sourceTree = "<group>"; };
 		941D71A9186298AA007D52D8 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		F1C7DEB71A52449C005F7001 /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		F1C7DEB81A52449C005F7001 /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -231,8 +231,8 @@
 		9417A74B1867DD3F00D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A74C1867DD3F00D9D37B /* AEFloatConverter.h */,
-				9417A74D1867DD3F00D9D37B /* AEFloatConverter.m */,
+				F1C7DEB71A52449C005F7001 /* EZ_AEFloatConverter.h */,
+				F1C7DEB81A52449C005F7001 /* EZ_AEFloatConverter.m */,
 				9417A74E1867DD3F00D9D37B /* EZAudio.h */,
 				9417A74F1867DD3F00D9D37B /* EZAudio.m */,
 				9417A7501867DD3F00D9D37B /* EZAudioFile.h */,
@@ -369,11 +369,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1C7DEB91A52449C005F7001 /* EZ_AEFloatConverter.m in Sources */,
 				9417A76F1867DD3F00D9D37B /* TPCircularBuffer.c in Sources */,
 				9417A76C1867DD3F00D9D37B /* EZOutput.m in Sources */,
 				9417A76A1867DD3F00D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
 				94056E74185BB44200EB94BA /* RecordViewController.m in Sources */,
-				9417A7651867DD3F00D9D37B /* AEFloatConverter.m in Sources */,
 				94056E20185BB3D800EB94BA /* AppDelegate.m in Sources */,
 				9417A7681867DD3F00D9D37B /* EZAudioPlot.m in Sources */,
 				9417A7671867DD3F00D9D37B /* EZAudioFile.m in Sources */,

--- a/EZAudioExamples/OSX/EZAudioWaveformFromFileExample/EZAudioWaveformFromFileExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/OSX/EZAudioWaveformFromFileExample/EZAudioWaveformFromFileExample.xcodeproj/project.pbxproj
@@ -27,7 +27,6 @@
 		94056EE9185BCDBF00EB94BA /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94056EE6185BCDBF00EB94BA /* CoreAudio.framework */; };
 		94056EEB185BCDC500EB94BA /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94056EEA185BCDC500EB94BA /* QuartzCore.framework */; };
 		9417A6D31865927500D9D37B /* simple-drum-beat.wav in Resources */ = {isa = PBXBuildFile; fileRef = 9417A6D21865927500D9D37B /* simple-drum-beat.wav */; };
-		9417A78C1867DD5400D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7741867DD5400D9D37B /* AEFloatConverter.m */; };
 		9417A78D1867DD5400D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7761867DD5400D9D37B /* EZAudio.m */; };
 		9417A78E1867DD5400D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7781867DD5400D9D37B /* EZAudioFile.m */; };
 		9417A78F1867DD5400D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A77A1867DD5400D9D37B /* EZAudioPlot.m */; };
@@ -40,6 +39,7 @@
 		9417A7961867DD5400D9D37B /* TPCircularBuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7871867DD5400D9D37B /* TPCircularBuffer.c */; };
 		9417A7971867DD5400D9D37B /* CHANGELOG in Resources */ = {isa = PBXBuildFile; fileRef = 9417A78A1867DD5400D9D37B /* CHANGELOG */; };
 		9417A7981867DD5400D9D37B /* VERSION in Resources */ = {isa = PBXBuildFile; fileRef = 9417A78B1867DD5400D9D37B /* VERSION */; };
+		F1C7DEBC1A5244A6005F7001 /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C7DEBB1A5244A6005F7001 /* EZ_AEFloatConverter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,8 +82,6 @@
 		94056EE6185BCDBF00EB94BA /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		94056EEA185BCDC500EB94BA /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		9417A6D21865927500D9D37B /* simple-drum-beat.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = "simple-drum-beat.wav"; path = "../../../simple-drum-beat.wav"; sourceTree = "<group>"; };
-		9417A7731867DD5400D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A7741867DD5400D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A7751867DD5400D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A7761867DD5400D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A7771867DD5400D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -106,6 +104,8 @@
 		9417A7881867DD5400D9D37B /* TPCircularBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPCircularBuffer.h; sourceTree = "<group>"; };
 		9417A78A1867DD5400D9D37B /* CHANGELOG */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CHANGELOG; sourceTree = "<group>"; };
 		9417A78B1867DD5400D9D37B /* VERSION */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = VERSION; sourceTree = "<group>"; };
+		F1C7DEBA1A5244A6005F7001 /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		F1C7DEBB1A5244A6005F7001 /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -230,8 +230,8 @@
 		9417A7721867DD5400D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A7731867DD5400D9D37B /* AEFloatConverter.h */,
-				9417A7741867DD5400D9D37B /* AEFloatConverter.m */,
+				F1C7DEBA1A5244A6005F7001 /* EZ_AEFloatConverter.h */,
+				F1C7DEBB1A5244A6005F7001 /* EZ_AEFloatConverter.m */,
 				9417A7751867DD5400D9D37B /* EZAudio.h */,
 				9417A7761867DD5400D9D37B /* EZAudio.m */,
 				9417A7771867DD5400D9D37B /* EZAudioFile.h */,
@@ -369,11 +369,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1C7DEBC1A5244A6005F7001 /* EZ_AEFloatConverter.m in Sources */,
 				9417A7961867DD5400D9D37B /* TPCircularBuffer.c in Sources */,
 				9417A7931867DD5400D9D37B /* EZOutput.m in Sources */,
 				9417A7911867DD5400D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
 				94056E96185BCBC000EB94BA /* AppDelegate.m in Sources */,
-				9417A78C1867DD5400D9D37B /* AEFloatConverter.m in Sources */,
 				94056EDE185BCC0200EB94BA /* WaveformFromFileViewController.m in Sources */,
 				9417A78F1867DD5400D9D37B /* EZAudioPlot.m in Sources */,
 				9417A78E1867DD5400D9D37B /* EZAudioFile.m in Sources */,

--- a/EZAudioExamples/iOS/EZAudioCoreGraphicsWaveformExample/EZAudioCoreGraphicsWaveformExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/iOS/EZAudioCoreGraphicsWaveformExample/EZAudioCoreGraphicsWaveformExample.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		94056FDE185E59D900EB94BA /* CoreGraphicsWaveformViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 94056FDD185E59D900EB94BA /* CoreGraphicsWaveformViewController.m */; };
 		94057024185E612100EB94BA /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94057023185E612000EB94BA /* AudioToolbox.framework */; };
 		94057026185E612A00EB94BA /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94057025185E612A00EB94BA /* GLKit.framework */; };
-		9417A7DA1867DDD600D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7C21867DDD600D9D37B /* AEFloatConverter.m */; };
+		9417A7DA1867DDD600D9D37B /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7C21867DDD600D9D37B /* EZ_AEFloatConverter.m */; };
 		9417A7DB1867DDD600D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7C41867DDD600D9D37B /* EZAudio.m */; };
 		9417A7DC1867DDD600D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7C61867DDD600D9D37B /* EZAudioFile.m */; };
 		9417A7DD1867DDD600D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7C81867DDD600D9D37B /* EZAudioPlot.m */; };
@@ -73,8 +73,8 @@
 		94056FDD185E59D900EB94BA /* CoreGraphicsWaveformViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreGraphicsWaveformViewController.m; sourceTree = "<group>"; };
 		94057023185E612000EB94BA /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		94057025185E612A00EB94BA /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
-		9417A7C11867DDD600D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A7C21867DDD600D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
+		9417A7C11867DDD600D9D37B /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		9417A7C21867DDD600D9D37B /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A7C31867DDD600D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A7C41867DDD600D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A7C51867DDD600D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -208,8 +208,8 @@
 		9417A7C01867DDD600D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A7C11867DDD600D9D37B /* AEFloatConverter.h */,
-				9417A7C21867DDD600D9D37B /* AEFloatConverter.m */,
+				9417A7C11867DDD600D9D37B /* EZ_AEFloatConverter.h */,
+				9417A7C21867DDD600D9D37B /* EZ_AEFloatConverter.m */,
 				9417A7C31867DDD600D9D37B /* EZAudio.h */,
 				9417A7C41867DDD600D9D37B /* EZAudio.m */,
 				9417A7C51867DDD600D9D37B /* EZAudioFile.h */,
@@ -349,7 +349,7 @@
 				9417A7E11867DDD600D9D37B /* EZOutput.m in Sources */,
 				9417A7DF1867DDD600D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
 				94056FDE185E59D900EB94BA /* CoreGraphicsWaveformViewController.m in Sources */,
-				9417A7DA1867DDD600D9D37B /* AEFloatConverter.m in Sources */,
+				9417A7DA1867DDD600D9D37B /* EZ_AEFloatConverter.m in Sources */,
 				94056F8E185E593500EB94BA /* AppDelegate.m in Sources */,
 				9417A7DD1867DDD600D9D37B /* EZAudioPlot.m in Sources */,
 				9417A7DC1867DDD600D9D37B /* EZAudioFile.m in Sources */,

--- a/EZAudioExamples/iOS/EZAudioFFTExample/EZAudioFFTExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/iOS/EZAudioFFTExample/EZAudioFFTExample.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		9417A99A1871E88300D9D37B /* EZAudioFFTExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A9991871E88300D9D37B /* EZAudioFFTExampleTests.m */; };
 		9417A9A41871E89500D9D37B /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A9A31871E89500D9D37B /* AudioToolbox.framework */; };
 		9417A9A61871E8A100D9D37B /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A9A51871E8A100D9D37B /* GLKit.framework */; };
-		9417A9C11871E96300D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A9A91871E96300D9D37B /* AEFloatConverter.m */; };
+		9417A9C11871E96300D9D37B /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A9A91871E96300D9D37B /* EZ_AEFloatConverter.m */; };
 		9417A9C21871E96300D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A9AB1871E96300D9D37B /* EZAudio.m */; };
 		9417A9C31871E96300D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A9AD1871E96300D9D37B /* EZAudioFile.m */; };
 		9417A9C41871E96300D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A9AF1871E96300D9D37B /* EZAudioPlot.m */; };
@@ -72,8 +72,8 @@
 		9417A9991871E88300D9D37B /* EZAudioFFTExampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EZAudioFFTExampleTests.m; sourceTree = "<group>"; };
 		9417A9A31871E89500D9D37B /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		9417A9A51871E8A100D9D37B /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
-		9417A9A81871E96300D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A9A91871E96300D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
+		9417A9A81871E96300D9D37B /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		9417A9A91871E96300D9D37B /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A9AA1871E96300D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A9AB1871E96300D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A9AC1871E96300D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -212,8 +212,8 @@
 		9417A9A71871E96300D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A9A81871E96300D9D37B /* AEFloatConverter.h */,
-				9417A9A91871E96300D9D37B /* AEFloatConverter.m */,
+				9417A9A81871E96300D9D37B /* EZ_AEFloatConverter.h */,
+				9417A9A91871E96300D9D37B /* EZ_AEFloatConverter.m */,
 				9417A9AA1871E96300D9D37B /* EZAudio.h */,
 				9417A9AB1871E96300D9D37B /* EZAudio.m */,
 				9417A9AC1871E96300D9D37B /* EZAudioFile.h */,
@@ -352,7 +352,7 @@
 				9417A9CB1871E96300D9D37B /* TPCircularBuffer.c in Sources */,
 				9417A9C81871E96300D9D37B /* EZOutput.m in Sources */,
 				9417A9C61871E96300D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
-				9417A9C11871E96300D9D37B /* AEFloatConverter.m in Sources */,
+				9417A9C11871E96300D9D37B /* EZ_AEFloatConverter.m in Sources */,
 				9417A97C1871E88300D9D37B /* AppDelegate.m in Sources */,
 				9417A9C41871E96300D9D37B /* EZAudioPlot.m in Sources */,
 				9417A9C31871E96300D9D37B /* EZAudioFile.m in Sources */,

--- a/EZAudioExamples/iOS/EZAudioOpenGLWaveformExample/EZAudioOpenGLWaveformExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/iOS/EZAudioOpenGLWaveformExample/EZAudioOpenGLWaveformExample.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		94057050185E636100EB94BA /* OpenGLWaveformViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9405704F185E636100EB94BA /* OpenGLWaveformViewController.m */; };
 		9417A6CB18658FC900D9D37B /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A6CA18658FC900D9D37B /* AudioToolbox.framework */; };
 		9417A6CD18658FCD00D9D37B /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A6CC18658FCD00D9D37B /* GLKit.framework */; };
-		9417A8011867DDE300D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7E91867DDE300D9D37B /* AEFloatConverter.m */; };
+		9417A8011867DDE300D9D37B /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7E91867DDE300D9D37B /* EZ_AEFloatConverter.m */; };
 		9417A8021867DDE300D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7EB1867DDE300D9D37B /* EZAudio.m */; };
 		9417A8031867DDE300D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7ED1867DDE300D9D37B /* EZAudioFile.m */; };
 		9417A8041867DDE300D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A7EF1867DDE300D9D37B /* EZAudioPlot.m */; };
@@ -73,8 +73,8 @@
 		9405704F185E636100EB94BA /* OpenGLWaveformViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OpenGLWaveformViewController.m; sourceTree = "<group>"; };
 		9417A6CA18658FC900D9D37B /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		9417A6CC18658FCD00D9D37B /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
-		9417A7E81867DDE300D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A7E91867DDE300D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
+		9417A7E81867DDE300D9D37B /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		9417A7E91867DDE300D9D37B /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A7EA1867DDE300D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A7EB1867DDE300D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A7EC1867DDE300D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -208,8 +208,8 @@
 		9417A7E71867DDE300D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A7E81867DDE300D9D37B /* AEFloatConverter.h */,
-				9417A7E91867DDE300D9D37B /* AEFloatConverter.m */,
+				9417A7E81867DDE300D9D37B /* EZ_AEFloatConverter.h */,
+				9417A7E91867DDE300D9D37B /* EZ_AEFloatConverter.m */,
 				9417A7EA1867DDE300D9D37B /* EZAudio.h */,
 				9417A7EB1867DDE300D9D37B /* EZAudio.m */,
 				9417A7EC1867DDE300D9D37B /* EZAudioFile.h */,
@@ -349,7 +349,7 @@
 				9417A8081867DDE300D9D37B /* EZOutput.m in Sources */,
 				9417A8061867DDE300D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
 				94057050185E636100EB94BA /* OpenGLWaveformViewController.m in Sources */,
-				9417A8011867DDE300D9D37B /* AEFloatConverter.m in Sources */,
+				9417A8011867DDE300D9D37B /* EZ_AEFloatConverter.m in Sources */,
 				94056FFC185E5EAF00EB94BA /* AppDelegate.m in Sources */,
 				9417A8041867DDE300D9D37B /* EZAudioPlot.m in Sources */,
 				9417A8031867DDE300D9D37B /* EZAudioFile.m in Sources */,

--- a/EZAudioExamples/iOS/EZAudioPassThroughExample/EZAudioPassThroughExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/iOS/EZAudioPassThroughExample/EZAudioPassThroughExample.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		9417A6BD18658F8800D9D37B /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A6BC18658F8800D9D37B /* AudioToolbox.framework */; };
 		9417A6BF18658F8D00D9D37B /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A6BE18658F8D00D9D37B /* GLKit.framework */; };
 		9417A6C518658FAA00D9D37B /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A6C418658FAA00D9D37B /* AVFoundation.framework */; };
-		9417A89D1867DE1E00D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8851867DE1E00D9D37B /* AEFloatConverter.m */; };
+		9417A89D1867DE1E00D9D37B /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8851867DE1E00D9D37B /* EZ_AEFloatConverter.m */; };
 		9417A89E1867DE1E00D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8871867DE1E00D9D37B /* EZAudio.m */; };
 		9417A89F1867DE1E00D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8891867DE1E00D9D37B /* EZAudioFile.m */; };
 		9417A8A01867DE1E00D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A88B1867DE1E00D9D37B /* EZAudioPlot.m */; };
@@ -74,8 +74,8 @@
 		9417A6BC18658F8800D9D37B /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		9417A6BE18658F8D00D9D37B /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
 		9417A6C418658FAA00D9D37B /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
-		9417A8841867DE1E00D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A8851867DE1E00D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
+		9417A8841867DE1E00D9D37B /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		9417A8851867DE1E00D9D37B /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A8861867DE1E00D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A8871867DE1E00D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A8881867DE1E00D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -208,8 +208,8 @@
 		9417A8831867DE1E00D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A8841867DE1E00D9D37B /* AEFloatConverter.h */,
-				9417A8851867DE1E00D9D37B /* AEFloatConverter.m */,
+				9417A8841867DE1E00D9D37B /* EZ_AEFloatConverter.h */,
+				9417A8851867DE1E00D9D37B /* EZ_AEFloatConverter.m */,
 				9417A8861867DE1E00D9D37B /* EZAudio.h */,
 				9417A8871867DE1E00D9D37B /* EZAudio.m */,
 				9417A8881867DE1E00D9D37B /* EZAudioFile.h */,
@@ -349,7 +349,7 @@
 				9417A8A41867DE1E00D9D37B /* EZOutput.m in Sources */,
 				9417A8A21867DE1E00D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
 				9417A61E1864D4DC00D9D37B /* AppDelegate.m in Sources */,
-				9417A89D1867DE1E00D9D37B /* AEFloatConverter.m in Sources */,
+				9417A89D1867DE1E00D9D37B /* EZ_AEFloatConverter.m in Sources */,
 				9417A61A1864D4DC00D9D37B /* main.m in Sources */,
 				9417A8A01867DE1E00D9D37B /* EZAudioPlot.m in Sources */,
 				9417A89F1867DE1E00D9D37B /* EZAudioFile.m in Sources */,

--- a/EZAudioExamples/iOS/EZAudioPlayFileExample/EZAudioPlayFileExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/iOS/EZAudioPlayFileExample/EZAudioPlayFileExample.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		9417A6C718658FB500D9D37B /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A6C618658FB500D9D37B /* AudioToolbox.framework */; };
 		9417A6C918658FC000D9D37B /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A6C818658FC000D9D37B /* GLKit.framework */; };
 		9417A6D1186591CA00D9D37B /* simple-drum-beat.wav in Resources */ = {isa = PBXBuildFile; fileRef = 9417A6D0186591CA00D9D37B /* simple-drum-beat.wav */; };
-		9417A8281867DDF600D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8101867DDF600D9D37B /* AEFloatConverter.m */; };
+		9417A8281867DDF600D9D37B /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8101867DDF600D9D37B /* EZ_AEFloatConverter.m */; };
 		9417A8291867DDF600D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8121867DDF600D9D37B /* EZAudio.m */; };
 		9417A82A1867DDF600D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8141867DDF600D9D37B /* EZAudioFile.m */; };
 		9417A82B1867DDF600D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8161867DDF600D9D37B /* EZAudioPlot.m */; };
@@ -55,8 +55,8 @@
 		9417A6C618658FB500D9D37B /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		9417A6C818658FC000D9D37B /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
 		9417A6D0186591CA00D9D37B /* simple-drum-beat.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = "simple-drum-beat.wav"; path = "../../../simple-drum-beat.wav"; sourceTree = "<group>"; };
-		9417A80F1867DDF600D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A8101867DDF600D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
+		9417A80F1867DDF600D9D37B /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		9417A8101867DDF600D9D37B /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A8111867DDF600D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A8121867DDF600D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A8131867DDF600D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -132,8 +132,8 @@
 		9417A80E1867DDF600D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A80F1867DDF600D9D37B /* AEFloatConverter.h */,
-				9417A8101867DDF600D9D37B /* AEFloatConverter.m */,
+				9417A80F1867DDF600D9D37B /* EZ_AEFloatConverter.h */,
+				9417A8101867DDF600D9D37B /* EZ_AEFloatConverter.m */,
 				9417A8111867DDF600D9D37B /* EZAudio.h */,
 				9417A8121867DDF600D9D37B /* EZAudio.m */,
 				9417A8131867DDF600D9D37B /* EZAudioFile.h */,
@@ -353,7 +353,7 @@
 				9417A82F1867DDF600D9D37B /* EZOutput.m in Sources */,
 				9417A82D1867DDF600D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
 				944D03ED186038A60076EF7A /* AppDelegate.m in Sources */,
-				9417A8281867DDF600D9D37B /* AEFloatConverter.m in Sources */,
+				9417A8281867DDF600D9D37B /* EZ_AEFloatConverter.m in Sources */,
 				944D043D1860398B0076EF7A /* PlayFileViewController.m in Sources */,
 				9417A82B1867DDF600D9D37B /* EZAudioPlot.m in Sources */,
 				9417A82A1867DDF600D9D37B /* EZAudioFile.m in Sources */,

--- a/EZAudioExamples/iOS/EZAudioRecordExample/EZAudioRecordExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/iOS/EZAudioRecordExample/EZAudioRecordExample.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		940570F8185E7F8300EB94BA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 940570F6185E7F8300EB94BA /* InfoPlist.strings */; };
 		940570FA185E7F8300EB94BA /* EZAudioRecordExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 940570F9185E7F8300EB94BA /* EZAudioRecordExampleTests.m */; };
 		94057105185E805900EB94BA /* RecordViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 94057104185E805900EB94BA /* RecordViewController.m */; };
-		9417A84F1867DE0300D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8371867DE0300D9D37B /* AEFloatConverter.m */; };
+		9417A84F1867DE0300D9D37B /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8371867DE0300D9D37B /* EZ_AEFloatConverter.m */; };
 		9417A8501867DE0300D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8391867DE0300D9D37B /* EZAudio.m */; };
 		9417A8511867DE0300D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A83B1867DE0300D9D37B /* EZAudioFile.m */; };
 		9417A8521867DE0300D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A83D1867DE0300D9D37B /* EZAudioPlot.m */; };
@@ -71,8 +71,8 @@
 		940570F9185E7F8300EB94BA /* EZAudioRecordExampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EZAudioRecordExampleTests.m; sourceTree = "<group>"; };
 		94057103185E805900EB94BA /* RecordViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RecordViewController.h; sourceTree = "<group>"; };
 		94057104185E805900EB94BA /* RecordViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RecordViewController.m; sourceTree = "<group>"; };
-		9417A8361867DE0300D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A8371867DE0300D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
+		9417A8361867DE0300D9D37B /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		9417A8371867DE0300D9D37B /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A8381867DE0300D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A8391867DE0300D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A83A1867DE0300D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -208,8 +208,8 @@
 		9417A8351867DE0300D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A8361867DE0300D9D37B /* AEFloatConverter.h */,
-				9417A8371867DE0300D9D37B /* AEFloatConverter.m */,
+				9417A8361867DE0300D9D37B /* EZ_AEFloatConverter.h */,
+				9417A8371867DE0300D9D37B /* EZ_AEFloatConverter.m */,
 				9417A8381867DE0300D9D37B /* EZAudio.h */,
 				9417A8391867DE0300D9D37B /* EZAudio.m */,
 				9417A83A1867DE0300D9D37B /* EZAudioFile.h */,
@@ -349,7 +349,7 @@
 				9417A8561867DE0300D9D37B /* EZOutput.m in Sources */,
 				9417A8541867DE0300D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
 				94057105185E805900EB94BA /* RecordViewController.m in Sources */,
-				9417A84F1867DE0300D9D37B /* AEFloatConverter.m in Sources */,
+				9417A84F1867DE0300D9D37B /* EZ_AEFloatConverter.m in Sources */,
 				940570DC185E7F8300EB94BA /* AppDelegate.m in Sources */,
 				9417A8521867DE0300D9D37B /* EZAudioPlot.m in Sources */,
 				9417A8511867DE0300D9D37B /* EZAudioFile.m in Sources */,

--- a/EZAudioExamples/iOS/EZAudioWaveformFromFileExample/EZAudioWaveformFromFileExample.xcodeproj/project.pbxproj
+++ b/EZAudioExamples/iOS/EZAudioWaveformFromFileExample/EZAudioWaveformFromFileExample.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		9417A6C118658F9700D9D37B /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A6C018658F9700D9D37B /* AudioToolbox.framework */; };
 		9417A6C318658F9C00D9D37B /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417A6C218658F9C00D9D37B /* GLKit.framework */; };
 		9417A6CF186591BC00D9D37B /* simple-drum-beat.wav in Resources */ = {isa = PBXBuildFile; fileRef = 9417A6CE186591BC00D9D37B /* simple-drum-beat.wav */; };
-		9417A8761867DE0F00D9D37B /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A85E1867DE0F00D9D37B /* AEFloatConverter.m */; };
+		9417A8761867DE0F00D9D37B /* EZ_AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A85E1867DE0F00D9D37B /* EZ_AEFloatConverter.m */; };
 		9417A8771867DE0F00D9D37B /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8601867DE0F00D9D37B /* EZAudio.m */; };
 		9417A8781867DE0F00D9D37B /* EZAudioFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8621867DE0F00D9D37B /* EZAudioFile.m */; };
 		9417A8791867DE0F00D9D37B /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9417A8641867DE0F00D9D37B /* EZAudioPlot.m */; };
@@ -75,8 +75,8 @@
 		9417A6C018658F9700D9D37B /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		9417A6C218658F9C00D9D37B /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
 		9417A6CE186591BC00D9D37B /* simple-drum-beat.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = "simple-drum-beat.wav"; path = "../../../simple-drum-beat.wav"; sourceTree = "<group>"; };
-		9417A85D1867DE0F00D9D37B /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
-		9417A85E1867DE0F00D9D37B /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
+		9417A85D1867DE0F00D9D37B /* EZ_AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZ_AEFloatConverter.h; sourceTree = "<group>"; };
+		9417A85E1867DE0F00D9D37B /* EZ_AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZ_AEFloatConverter.m; sourceTree = "<group>"; };
 		9417A85F1867DE0F00D9D37B /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
 		9417A8601867DE0F00D9D37B /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
 		9417A8611867DE0F00D9D37B /* EZAudioFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFile.h; sourceTree = "<group>"; };
@@ -211,8 +211,8 @@
 		9417A85C1867DE0F00D9D37B /* EZAudio */ = {
 			isa = PBXGroup;
 			children = (
-				9417A85D1867DE0F00D9D37B /* AEFloatConverter.h */,
-				9417A85E1867DE0F00D9D37B /* AEFloatConverter.m */,
+				9417A85D1867DE0F00D9D37B /* EZ_AEFloatConverter.h */,
+				9417A85E1867DE0F00D9D37B /* EZ_AEFloatConverter.m */,
 				9417A85F1867DE0F00D9D37B /* EZAudio.h */,
 				9417A8601867DE0F00D9D37B /* EZAudio.m */,
 				9417A8611867DE0F00D9D37B /* EZAudioFile.h */,
@@ -353,7 +353,7 @@
 				9417A87D1867DE0F00D9D37B /* EZOutput.m in Sources */,
 				9417A87B1867DE0F00D9D37B /* EZAudioPlotGLKViewController.m in Sources */,
 				9405706E185E69D400EB94BA /* AppDelegate.m in Sources */,
-				9417A8761867DE0F00D9D37B /* AEFloatConverter.m in Sources */,
+				9417A8761867DE0F00D9D37B /* EZ_AEFloatConverter.m in Sources */,
 				940570BE185E6A0400EB94BA /* WaveformFromFileViewController.m in Sources */,
 				9417A8791867DE0F00D9D37B /* EZAudioPlot.m in Sources */,
 				9417A8781867DE0F00D9D37B /* EZAudioFile.m in Sources */,


### PR DESCRIPTION
I'm using The Amazing Audio Engine in my project and wanted to use EZAudio for waveform display. This PR resolves naming conflicts between the two pods.