### PR TITLE
Fixed warnings with deprecated "canonical" flags

### DIFF
--- a/EZAudio/EZAudio.m
+++ b/EZAudio/EZAudio.m
@@ -144,7 +144,7 @@
     asbd.mBytesPerFrame    = byteSize;
     asbd.mBytesPerPacket   = byteSize;
     asbd.mChannelsPerFrame = 1;
-    asbd.mFormatFlags      = kAudioFormatFlagsCanonical|kAudioFormatFlagIsNonInterleaved;
+    asbd.mFormatFlags      = kAudioFormatFlagsNativeFloatPacked|kAudioFormatFlagIsNonInterleaved;
     asbd.mFormatID         = kAudioFormatLinearPCM;
     asbd.mFramesPerPacket  = 1;
     asbd.mSampleRate       = sampleRate;
@@ -159,7 +159,7 @@
     asbd.mBytesPerFrame    = byteSize;
     asbd.mBytesPerPacket   = byteSize;
     asbd.mChannelsPerFrame = 2;
-    asbd.mFormatFlags      = kAudioFormatFlagsCanonical|kAudioFormatFlagIsNonInterleaved;
+    asbd.mFormatFlags      = kAudioFormatFlagsNativeFloatPacked|kAudioFormatFlagIsNonInterleaved;
     asbd.mFormatID         = kAudioFormatLinearPCM;
     asbd.mFramesPerPacket  = 1;
     asbd.mSampleRate       = sampleRate;
@@ -218,7 +218,7 @@
     asbd->mFormatID = kAudioFormatLinearPCM;
 #if TARGET_OS_IPHONE
     int sampleSize = sizeof(float);
-    asbd->mFormatFlags = kAudioFormatFlagsCanonical;
+    asbd->mFormatFlags = kAudioFormatFlagsNativeFloatPacked;
 #elif TARGET_OS_MAC
     int sampleSize = sizeof(Float32);
     asbd->mFormatFlags = kAudioFormatFlagsNativeFloatPacked;


### PR DESCRIPTION
This is a quote from a file CoreAudio/CoreAudioTypes.h:
> The "canonical" flags are deprecated. CA_PREFER_FIXED_POINT is discouraged because floating-point performance on iOS is such that fixed point is no longer truly preferred. All Apple-supplied AudioUnits support floating point. Replacement should be done with carefulconsideration of the format being specified or expected, but oftenkAudioFormatFlagsCanonical can be replaced with kAudioFormatFlagsNativeFloatPacked, andkAudioFormatFlagsAudioUnitCanonical with kAudioFormatFlagsNativeFloatPacked | kAudioFormatFlagIsNonInterleaved.