### PR TITLE
change the header files import position in EZPlot.h

### DIFF
--- a/EZAudio/EZPlot.h
+++ b/EZAudio/EZPlot.h
@@ -23,6 +23,21 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+/**
+ EZPlot is a cross-platform (iOS and OSX) class used to subclass the default view type (either UIView or NSView, respectively).
+ 
+ ## Subclassing Notes
+ 
+ This class isn't meant to be directly used in practice, but instead establishes the default properties and behaviors subclasses should obey to provide consistent behavior accross multiple types of graphs (i.e. set background color, plot type, should fill in, etc.). Subclasses should make use of the inherited properties from this class to allow all child plots to benefit from the same 
+ */
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+@interface EZPlot : UIView
+#elif TARGET_OS_MAC
+#import <Cocoa/Cocoa.h>
+@interface EZPlot : NSView
+#endif
+
 #pragma mark - Enumerations
 ///-----------------------------------------------------------
 /// @name Plot Types
@@ -41,21 +56,6 @@ typedef NS_ENUM(NSInteger,EZPlotType){
    */
   EZPlotTypeRolling
 };
-
-/**
- EZPlot is a cross-platform (iOS and OSX) class used to subclass the default view type (either UIView or NSView, respectively).
- 
- ## Subclassing Notes
- 
- This class isn't meant to be directly used in practice, but instead establishes the default properties and behaviors subclasses should obey to provide consistent behavior accross multiple types of graphs (i.e. set background color, plot type, should fill in, etc.). Subclasses should make use of the inherited properties from this class to allow all child plots to benefit from the same 
- */
-#if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
-@interface EZPlot : UIView
-#elif TARGET_OS_MAC
-#import <Cocoa/Cocoa.h>
-@interface EZPlot : NSView
-#endif
 
 #pragma mark - Properties
 ///-----------------------------------------------------------


### PR DESCRIPTION
I added EZAudio in Podfile, but received an error in EZPlot.h(below is the error screenshot).

So I changed the import position.

![ezaudioerror](https://cloud.githubusercontent.com/assets/8135815/6895864/28050d6e-d717-11e4-832b-3323f67b061a.png)
