### PR TITLE
Fixed two memory leaks in EZMicrophone

### DIFF
--- a/EZAudio/EZMicrophone.m
+++ b/EZAudio/EZMicrophone.m
@@ -596,4 +596,13 @@ static OSStatus inputCallback(void                          *inRefCon,
              operation:"Could not disable audio unit allocating its own buffers"];
 }
 
+-(void)dealloc {
+    [EZAudio freeBufferList:microphoneInputBuffer];
+    for ( int i=0; i<streamFormat.mChannelsPerFrame; i++ ) {
+        free(floatBuffers[i]);
+    }
+    free(floatBuffers);
+    floatBuffers = NULL;
+}
+
 @end


### PR DESCRIPTION
The variables `microphoneInputBuffer` and `floatBuffers` in `EZMicrophone` are allocated but are **not subsequently deallocated (freed)**. 

The memory leaks are visible in this leaks instrumentation screenshot:
![Memory Leak](http://i.imgur.com/vvO3GBt.png)

After running this fix, the **leaks are gone** as per the results here: 
![Memory Leak Fixed](http://i.imgur.com/mbtS3Rb.png)