### PR TITLE
Fixed memory leak in EZAudioFile

### DIFF
--- a/EZAudio/EZAudioFile.m
+++ b/EZAudio/EZAudioFile.m
@@ -351,10 +351,11 @@
     free(_waveformData);
     _waveformData = NULL;
   }
-//  if( _floatBuffers ){
-//    free(_floatBuffers);
-//    _floatBuffers = NULL;
-//  }
+  for ( int i=0; i< _clientFormat.mChannelsPerFrame; i++ ) {
+    free(_floatBuffers[i]);
+  }
+  free(_floatBuffers);
+  _floatBuffers = NULL;
   _frameIndex = 0;
   _waveformFrameRate = 0;
   _waveformTotalBuffers = 0;


### PR DESCRIPTION
The variable `_floatBuffers` is allocated but is **not subsequently deallocated (freed)**. 

Some **memory management was present** for `_floatBuffers` in this commit: [2431b2520496118cdc09af6b9984661285e38c52](https://github.com/syedhali/EZAudio/commit/2431b2520496118cdc09af6b99846)

However, this was subsequently **commented out** in a later commit: [1dc2fc2ba902f6fa9b1f8ec2c0c7794aa7d66ee2](https://github.com/syedhali/EZAudio/commit/1dc2fc2ba902f6fa9b1f8ec2c0c7794aa7d66ee2). 

I have made two changes to this:
1. Uncommented the memory management code
2. Deallocated `_floatBuffers[i]` elements that were malloc'ed, but have never been deallocated

Note: `if( _floatBuffers ){` is removed because:

> The `free` function causes the space pointed to by `ptr` to be deallocated, that is, made available for further allocation. If `ptr` is a null pointer, no action occurs.
> Source: [ISO/IEC 9899:1999 p313](http://www.open-std.org/JTC1/SC22/wg14/www/docs/n1124.pdf) or [this stack overflow post](http://stackoverflow.com/a/1938758/2668226)