### PR TITLE
Fix deadlock from drawing 8k of buffer data in context

### DIFF
--- a/EZAudio/EZAudioPlot.m
+++ b/EZAudio/EZAudioPlot.m
@@ -140,6 +140,12 @@
     free(plotData);
   }
   
+                  //fixes issue where sometimes first sample data is 8k long, and locks thread
+                  //for very intense drawing operation
+                  if (length > self.rollingHistoryLength) {
+                      return;
+                  }
+                  
   plotData   = (CGPoint *)calloc(sizeof(CGPoint),length);
   plotLength = length;
   


### PR DESCRIPTION
I noticed that sometimes this method would be called with a length of 8192 -- enough time to deadlock Thread 1 on my iPhone 6 Plus for 8-10 seconds. It *seems* like it is by design (`_setMaxLength = YES`) but I don't understand why. 

Anyway, this Pull Request might be getting at the wrong issue, but I submit it as a way of highlighting an issue that was giving me problems.