### PR TITLE
Cocoapod compatibility with External lib

### DIFF
--- a/EZAudio/EZAudio.h
+++ b/EZAudio/EZAudio.h
@@ -26,8 +26,11 @@
 #import <Foundation/Foundation.h>
 
 #pragma mark - 3rd Party Utilties
-//#import "TPCircularBuffer.h"
+#if COCOAPODS
 #import <TPCircularBuffer/TPCircularBuffer.h>
+#else
+#import "TPCircularBuffer.h"
+#endif
 
 #pragma mark - Core Components
 #import "EZAudioFile.h"

--- a/EZAudio/EZAudio.h
+++ b/EZAudio/EZAudio.h
@@ -26,7 +26,8 @@
 #import <Foundation/Foundation.h>
 
 #pragma mark - 3rd Party Utilties
-#import "TPCircularBuffer.h"
+//#import "TPCircularBuffer.h"
+#import <TPCircularBuffer/TPCircularBuffer.h>
 
 #pragma mark - Core Components
 #import "EZAudioFile.h"

--- a/EZAudio/EZAudioUtilities.h
+++ b/EZAudio/EZAudioUtilities.h
@@ -25,8 +25,11 @@
 
 #import <Foundation/Foundation.h>
 #import <AudioToolbox/AudioToolbox.h>
-//#import "TPCircularBuffer.h"
+#if COCOAPODS
 #import <TPCircularBuffer/TPCircularBuffer.h>
+#else
+#import "TPCircularBuffer.h"
+#endif
 
 #if TARGET_OS_IPHONE
 #import <AVFoundation/AVFoundation.h>

--- a/EZAudio/EZAudioUtilities.h
+++ b/EZAudio/EZAudioUtilities.h
@@ -25,7 +25,8 @@
 
 #import <Foundation/Foundation.h>
 #import <AudioToolbox/AudioToolbox.h>
-#import "TPCircularBuffer.h"
+//#import "TPCircularBuffer.h"
+#import <TPCircularBuffer/TPCircularBuffer.h>
 
 #if TARGET_OS_IPHONE
 #import <AVFoundation/AVFoundation.h>

--- a/EZAudio/EZOutput.h
+++ b/EZAudio/EZOutput.h
@@ -30,8 +30,11 @@
 #import <AudioUnit/AudioUnit.h>
 #endif
 
-//#import "TPCircularBuffer.h"
+#if COCOAPODS
 #import <TPCircularBuffer/TPCircularBuffer.h>
+#else
+#import "TPCircularBuffer.h"
+#endif
 
 @class EZOutput;
 

--- a/EZAudio/EZOutput.h
+++ b/EZAudio/EZOutput.h
@@ -30,7 +30,8 @@
 #import <AudioUnit/AudioUnit.h>
 #endif
 
-#import "TPCircularBuffer.h"
+//#import "TPCircularBuffer.h"
+#import <TPCircularBuffer/TPCircularBuffer.h>
 
 @class EZOutput;
 

--- a/EZAudio/TPCircularBuffer.c
+++ b/EZAudio/TPCircularBuffer.c
@@ -27,7 +27,8 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
-#include "TPCircularBuffer.h"
+//#import "TPCircularBuffer.h"
+#import <TPCircularBuffer/TPCircularBuffer.h>
 #include <mach/mach.h>
 #include <stdio.h>
 

--- a/EZAudio/TPCircularBuffer.c
+++ b/EZAudio/TPCircularBuffer.c
@@ -27,8 +27,12 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //
 
-//#import "TPCircularBuffer.h"
+#if COCOAPODS
 #import <TPCircularBuffer/TPCircularBuffer.h>
+#else
+#import "TPCircularBuffer.h"
+#endif
+
 #include <mach/mach.h>
 #include <stdio.h>
 


### PR DESCRIPTION
Using preprocessor macro to import external library TPCircularBuffer to be usable with or without cocoapods