### PR TITLE
implement delegate method to find out when an audio file reached end, and also which file

### DIFF
--- a/EZAudio/EZAudioPlayer.h
+++ b/EZAudio/EZAudioPlayer.h
@@ -110,6 +110,11 @@ FOUNDATION_EXPORT NSString * const EZAudioPlayerDidSeekNotification;
         inAudioFile:(EZAudioFile *)audioFile;
 
 
+/**
+ Triggered by EZAudioPlayer's internal EZAudioFile's EZAudioFileDelegate callback and notifies the delegate that the end of the file has been reached. 
+ @param audioPlayer The instance of the EZAudioPlayer that triggered the event
+ @param audioFile   The instance of the EZAudioFile that the event was triggered from
+ */
 - (void)audioPlayer:(EZAudioPlayer *)audioPlayer
 reachedEndOfAudioFile:(EZAudioFile *)audioFile;
 

--- a/EZAudio/EZAudioPlayer.h
+++ b/EZAudio/EZAudioPlayer.h
@@ -109,6 +109,10 @@ FOUNDATION_EXPORT NSString * const EZAudioPlayerDidSeekNotification;
     updatedPosition:(SInt64)framePosition
         inAudioFile:(EZAudioFile *)audioFile;
 
+
+- (void)audioPlayer:(EZAudioPlayer *)audioPlayer
+reachedEndOfAudioFile:(EZAudioFile *)audioFile;
+
 @end
 
 //------------------------------------------------------------------------------

--- a/EZAudio/EZAudioPlayer.m
+++ b/EZAudio/EZAudioPlayer.m
@@ -372,6 +372,9 @@ NSString * const EZAudioPlayerDidSeekNotification = @"EZAudioPlayerDidSeekNotifi
                    audioBufferList:audioBufferList
                         bufferSize:&bufferSize
                                eof:&eof];
+        if (eof && [self.delegate respondsToSelector:@selector(audioPlayer:reachedEndOfAudioFile:)]) {
+            [self.delegate audioPlayer:self reachedEndOfAudioFile:self.audioFile];
+        }
         if (eof && self.shouldLoop)
         {
             [self seekToFrame:0];

--- a/EZAudio/EZAudioPlayer.m
+++ b/EZAudio/EZAudioPlayer.m
@@ -372,7 +372,8 @@ NSString * const EZAudioPlayerDidSeekNotification = @"EZAudioPlayerDidSeekNotifi
                    audioBufferList:audioBufferList
                         bufferSize:&bufferSize
                                eof:&eof];
-        if (eof && [self.delegate respondsToSelector:@selector(audioPlayer:reachedEndOfAudioFile:)]) {
+        if (eof && [self.delegate respondsToSelector:@selector(audioPlayer:reachedEndOfAudioFile:)]) 
+        {
             [self.delegate audioPlayer:self reachedEndOfAudioFile:self.audioFile];
         }
         if (eof && self.shouldLoop)


### PR DESCRIPTION
Here's a new PR for this feature. I really need it as a delegate method (like it was spec'd in the previous version of the EZAudioFilePlayerDelegate) rather than notification, so here goes.  Works perfectly.