### PR TITLE
EXC_BAD_ACCESS is fixed

### DIFF
--- a/EZAudio/EZAudioUtilities.m
+++ b/EZAudio/EZAudioUtilities.m
@@ -106,6 +106,11 @@ BOOL __shouldExitOnCheckResultFail = YES;
 
 + (void)freeFloatBuffers:(float **)buffers numberOfChannels:(UInt32)channels
 {
+    if (!buffers || !*buffers)
+    {
+        return;
+    }
+
     for (int i = 0; i < channels; i++)
     {
         free(buffers[i]);


### PR DESCRIPTION
EXC_BAD_ACCESS  occurs in initWithMicrophoneDelegate:withAudioStreamBasicDescription: during initial creation of EZMicrophone.
[EZMicrophone setup] calls [self setAudioStreamBasicDescription:self.info->streamFormat] which in turn calls [EZAudioUtilities freeFloatBuffers:self.info->floatData numberOfChannels:self.info->streamFormat.mChannelsPerFrame];
where self.info->floatData is NULL.