### PR TITLE
Do not call exit on non-DEBUG builds

### DIFF
--- a/EZAudio/EZAudioUtilities.m
+++ b/EZAudio/EZAudioUtilities.m
@@ -537,10 +537,12 @@ BOOL __shouldExitOnCheckResultFail = YES;
         // no, format it as an integer
         sprintf(errorString, "%d", (int)result);
     fprintf(stderr, "Error: %s (%s)\n", operation, errorString);
+#if DEBUG
     if (__shouldExitOnCheckResultFail)
     {
         exit(-1);
     }
+#endif
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Calling exit() accidentally on a production build would be a bad thing.

syedhali/EZAudio#82 is relevant here.