### PR TITLE
Initialize struct values to 0 based on docs

### DIFF
--- a/EZAudio/EZMicrophone.m
+++ b/EZAudio/EZMicrophone.m
@@ -217,6 +217,9 @@ static OSStatus EZAudioMicrophoneCallback(void                       *inRefCon,
 #elif TARGET_OS_MAC
     inputComponentDescription.componentSubType = kAudioUnitSubType_HALOutput;
 #endif
+    // The following must be set to zero unless a specific value is requested.
+    inputComponentDescription.componentFlags = 0;
+    inputComponentDescription.componentFlagsMask = 0;
     
     // get the first matching component
     AudioComponent inputComponent = AudioComponentFindNext( NULL , &inputComponentDescription);


### PR DESCRIPTION
The docs for AudioComponentDescription say that componentFlags and
componentFlagsMask must be set to 0 unless specific values are
requested.

Different platforms (32 vs 64 bit) initialize data to different starting
values. Ensure the AudioComponentDescription is initialized to prevent
unwanted side effects.