### PR TITLE
modify EZAudioDevice internal implementation

### DIFF
--- a/EZAudio/EZAudioDevice.m
+++ b/EZAudio/EZAudioDevice.m
@@ -117,7 +117,7 @@
         return;
     }
     
-    BOOL stop;
+    BOOL stop = NO;
     for (AVAudioSessionPortDescription *inputDevicePortDescription in inputs)
     {
         // add any additional sub-devices
@@ -130,6 +130,10 @@
                 device.port = inputDevicePortDescription;
                 device.dataSource = inputDeviceDataSourceDescription;
                 block(device, &stop);
+                if (stop)
+                {
+                    break;
+                }
             }
         }
         else
@@ -153,7 +157,7 @@
     AVAudioSessionRouteDescription *currentRoute = [[AVAudioSession sharedInstance] currentRoute];
     NSArray *portDescriptions = [currentRoute outputs];
     
-    BOOL stop;
+    BOOL stop = NO;
     for (AVAudioSessionPortDescription *outputDevicePortDescription in portDescriptions)
     {
         // add any additional sub-devices
@@ -166,6 +170,10 @@
                 device.port = outputDevicePortDescription;
                 device.dataSource = outputDeviceDataSourceDescription;
                 block(device, &stop);
+                if (stop)
+                {
+                    break;
+                }
             }
         }
         else


### PR DESCRIPTION
I check out the part for OS X and found maybe you want to make the internal devices enumeration methods implemented like NSArray:
```objc
+ (void)enumerateDevicesUsingBlock:(void(^)(EZAudioDevice *device,
                                            BOOL *stop))block
{
    if (!block)
    {
        return;
    }
    
    // get the present system devices
    AudioObjectPropertyAddress address = [self addressForPropertySelector:kAudioHardwarePropertyDevices];
    UInt32 devicesDataSize;
    [EZAudioUtilities checkResult:AudioObjectGetPropertyDataSize(kAudioObjectSystemObject,
                                                                 &address,
                                                                 0,
                                                                 NULL,
                                                                 &devicesDataSize)
                        operation:"Failed to get data size"];
    
    // enumerate devices
    NSInteger count = devicesDataSize / sizeof(AudioDeviceID);
    AudioDeviceID *deviceIDs = (AudioDeviceID *)malloc(devicesDataSize);
    
    // fill in the devices
    [EZAudioUtilities checkResult:AudioObjectGetPropertyData(kAudioObjectSystemObject,
                                                             &address,
                                                             0,
                                                             NULL,
                                                             &devicesDataSize,
                                                             deviceIDs)
                        operation:"Failed to get device IDs for available devices on OSX"];

    BOOL stop = NO;
    for (UInt32 i = 0; i < count; i++)
    {
        AudioDeviceID deviceID = deviceIDs[i];
        EZAudioDevice *device = [[EZAudioDevice alloc] init];
        device.deviceID = deviceID;
        device.manufacturer = [self manufacturerForDeviceID:deviceID];
        device.name = [self namePropertyForDeviceID:deviceID];
        device.UID = [self UIDPropertyForDeviceID:deviceID];
        device.inputChannelCount = [self channelCountForScope:kAudioObjectPropertyScopeInput forDeviceID:deviceID];
        device.outputChannelCount = [self channelCountForScope:kAudioObjectPropertyScopeOutput forDeviceID:deviceID];
        block(device, &stop);
        if (stop)
        {
            break;
        }
    }
    
    free(deviceIDs);
}
```
but the part for iOS is not implemented like that.