### PR TITLE
Add framework header guards.

### DIFF
--- a/EZAudio/EZAudio.h
+++ b/EZAudio/EZAudio.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 //! Project version number for teat.

--- a/EZAudio/EZAudioDevice.h
+++ b/EZAudio/EZAudioDevice.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 

--- a/EZAudio/EZAudioDisplayLink.h
+++ b/EZAudio/EZAudioDisplayLink.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
 

--- a/EZAudio/EZAudioFFT.h
+++ b/EZAudio/EZAudioFFT.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import <Accelerate/Accelerate.h>
 

--- a/EZAudio/EZAudioFile.h
+++ b/EZAudio/EZAudioFile.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 #import "EZAudioFloatData.h"

--- a/EZAudio/EZAudioFloatConverter.h
+++ b/EZAudio/EZAudioFloatConverter.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 

--- a/EZAudio/EZAudioFloatData.h
+++ b/EZAudio/EZAudioFloatData.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 
 //------------------------------------------------------------------------------

--- a/EZAudio/EZAudioPlayer.h
+++ b/EZAudio/EZAudioPlayer.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import "TargetConditionals.h"
 #import "EZAudioFile.h"

--- a/EZAudio/EZAudioPlot.h
+++ b/EZAudio/EZAudioPlot.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <QuartzCore/QuartzCore.h>
 #import "EZPlot.h"
 #import "EZAudioDisplayLink.h"

--- a/EZAudio/EZAudioPlotGL.h
+++ b/EZAudio/EZAudioPlotGL.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <GLKit/GLKit.h>
 #import "EZPlot.h"
 #if !TARGET_OS_IPHONE

--- a/EZAudio/EZAudioUtilities.h
+++ b/EZAudio/EZAudioUtilities.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 #import <TargetConditionals.h>

--- a/EZAudio/EZMicrophone.h
+++ b/EZAudio/EZMicrophone.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 #import "TargetConditionals.h"

--- a/EZAudio/EZOutput.h
+++ b/EZAudio/EZOutput.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 #if TARGET_OS_IPHONE

--- a/EZAudio/EZPlot.h
+++ b/EZAudio/EZPlot.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import "EZAudioUtilities.h"
 

--- a/EZAudio/EZRecorder.h
+++ b/EZAudio/EZRecorder.h
@@ -23,6 +23,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 


### PR DESCRIPTION
This fixes duplicate definitions issues when including framework headers from multiple translation unit locations.
