### PR TITLE
Fixed method name for getting currently selected output device

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Similarly, to get all the available output devices use the `outputDevices` class
 NSArray *outputDevices = [EZAudioDevice outputDevices];
 ```
 
-or to just get the currently selected output device use the `currentInputDevice` method:
+or to just get the currently selected output device use the `currentOutputDevice` method:
 ```objectivec
 // On iOS this will default to the headset speaker, while on OSX this will be your selected
 // output device from the Sound preferences


### PR DESCRIPTION
This is just a small typo in the documentation but the method name should be `currentOutputDevice` instead of `currentInputDevice` for getting the currently selected output device.