### PR TITLE
fix bug when using UIColor presets

### DIFF
--- a/EZAudio/EZAudioUtilities.m
+++ b/EZAudio/EZAudioUtilities.m
@@ -622,6 +622,17 @@ BOOL __shouldExitOnCheckResultFail = YES;
         *blue = components[2];
         *alpha = components[3];
     }
+    else if (componentCount == 2)
+    {
+        const CGFloat *components = CGColorGetComponents(color);
+        *red = components[0];
+        *green = components[0];
+        *blue = components[0];
+        *alpha = components[1];
+    }
+    else {
+		// should throw an exception maybe
+	}
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
There was a bug that in some cases could have `glClearColor` set to undefined value. 

The cause of this bug is the method

```objc
+ (void)getColorComponentsFromCGColor:(CGColorRef)color
                                  red:(CGFloat *)red
                                green:(CGFloat *)green
                                 blue:(CGFloat *)blue
                                alpha:(CGFloat *)alpha
```

That supposed the  `CGColorSpaceRef` returned by the `UIColor` was always `kCGColorSpaceGenericRGB` (see below)

```objc
- (void)setBackgroundColor:(id)backgroundColor
{
    _backgroundColor = backgroundColor;
    if (backgroundColor)
    {
        CGColorRef colorRef = [backgroundColor CGColor];
        CGFloat red; CGFloat green; CGFloat blue; CGFloat alpha;
        [EZAudioUtilities getColorComponentsFromCGColor:colorRef
                                                    red:&red
                                                  green:&green
                                                   blue:&blue
                                                  alpha:&alpha];
        //
        // Note! If you set the alpha to be 0 on mac for a transparent view
        // the EZAudioPlotGL will make the superview layer-backed to make
        // sure there is a surface to display itself on (or else you will get
        // some pretty weird drawing glitches
        //
#if !TARGET_OS_IPHONE
        if (alpha == 0.0f)
        {
            [self.superview setWantsLayer:YES];
        }
#endif
        glClearColor(red, green, blue, alpha);
    }
    else
    {
        glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
    }
}
```

Notice that's not true when you pass as `UIColor` things like `[UIColor whiteColor]`