### PR TITLE
Level-dependent waveform fadeout

### DIFF
--- a/EZAudio/EZAudioPlot.h
+++ b/EZAudio/EZAudioPlot.h
@@ -204,4 +204,6 @@ FOUNDATION_EXPORT UInt32 const EZAudioPlotDefaultMaxHistoryBufferLength;
 @property (nonatomic, assign) EZPlotHistoryInfo  *historyInfo;
 @property (nonatomic, assign) CGPoint            *points;
 @property (nonatomic, assign) UInt32              pointCount;
+@property (nonatomic, assign) UIColor            *originalColor;
+@property (nonatomic, assign) Boolean            fadeOut;
 @end

--- a/EZAudio/EZAudioPlot.h
+++ b/EZAudio/EZAudioPlot.h
@@ -188,7 +188,7 @@ FOUNDATION_EXPORT UInt32 const EZAudioPlotDefaultMaxHistoryBufferLength;
 //------------------------------------------------------------------------------
 
 /**
- Main method used to copy the sample data from the source buffer and update the 
+ Main method used to copy the sample data from the source buffer and update the
  plot. Subclasses can overwrite this method for custom behavior.
  @param data   A float array of the sample data. Subclasses should copy this data to a separate array to avoid threading issues.
  @param length The length of the float array as an int.
@@ -196,6 +196,15 @@ FOUNDATION_EXPORT UInt32 const EZAudioPlotDefaultMaxHistoryBufferLength;
 -(void)setSampleData:(float *)data length:(int)length;
 
 //------------------------------------------------------------------------------
+
+/**
+ Used to alter the color of the waveform, but keeps the original color intact, you cou can always revert to the init state.
+ @param color   A UIColor you'd like to set the waveform to.
+ */
+- (void)updateColor:(id)color;
+
+//------------------------------------------------------------------------------
+
 
 @end
 
@@ -205,5 +214,5 @@ FOUNDATION_EXPORT UInt32 const EZAudioPlotDefaultMaxHistoryBufferLength;
 @property (nonatomic, assign) CGPoint            *points;
 @property (nonatomic, assign) UInt32              pointCount;
 @property (nonatomic, assign) UIColor            *originalColor;
-@property (nonatomic, assign) Boolean            fadeOut;
+@property (nonatomic, assign) BOOL                fadeOut;
 @end

--- a/EZAudio/EZAudioPlot.m
+++ b/EZAudio/EZAudioPlot.m
@@ -202,8 +202,6 @@ UInt32 const EZAudioPlotDefaultMaxHistoryBufferLength = 8192;
 }
 - (void)updateColor:(id)color
 {
-    [super setColor:color];
-    
     self.waveformLayer.strokeColor = [color CGColor];
     if (self.shouldFill)
     {
@@ -292,10 +290,11 @@ UInt32 const EZAudioPlotDefaultMaxHistoryBufferLength = 8192;
             double opacityThreshold = 0.0001;
             double opacityVal = 1.0;
             if(fabs(avg) < opacityThreshold){
-                opacityVal = pow(fabs(avg)/opacityThreshold,5);
+                opacityVal = pow(fabs(avg)/opacityThreshold,2);
             }
             [self updateColor:[self.originalColor colorWithAlphaComponent:(CGFloat)opacityVal]];
-            
+        }else{
+            [self updateColor:self.originalColor];
         }
         path = CGPathCreateMutable();
         double xscale = (rect.size.width) / ((float)self.pointCount);

--- a/EZAudioExamples/iOS/CoreGraphicsWaveform/CoreGraphicsWaveform/Base.lproj/Main.storyboard
+++ b/EZAudioExamples/iOS/CoreGraphicsWaveform/CoreGraphicsWaveform/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="VVE-1A-cqe">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="VVE-1A-cqe">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -54,6 +54,13 @@
                                     <action selector="toggleMicrophone:" destination="VVE-1A-cqe" eventType="touchUpInside" id="WgY-ud-zXC"/>
                                 </connections>
                             </switch>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nft-qL-QZ9" userLabel="FadeOutSwitch">
+                                <rect key="frame" x="536" y="479" width="51" height="31"/>
+                                <color key="onTintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <connections>
+                                    <action selector="toggleFadeout:" destination="VVE-1A-cqe" eventType="touchUpInside" id="BQ7-7J-aLl"/>
+                                </connections>
+                            </switch>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CmL-jc-Qh5">
                                 <rect key="frame" x="73" y="487" width="33" height="16"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
@@ -73,8 +80,10 @@
                             <constraint firstAttribute="trailing" secondItem="Rzq-Yi-IN7" secondAttribute="trailing" id="6Sb-Bo-0wK"/>
                             <constraint firstItem="Vyk-X1-klK" firstAttribute="top" secondItem="Rzq-Yi-IN7" secondAttribute="bottom" id="8Sc-T9-Q3z"/>
                             <constraint firstItem="LOY-0w-MaL" firstAttribute="top" secondItem="CmL-jc-Qh5" secondAttribute="bottom" constant="17" id="BXP-tk-dIP"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="Nft-qL-QZ9" secondAttribute="trailing" constant="-5" id="CbV-Fg-ecU"/>
                             <constraint firstItem="Rzq-Yi-IN7" firstAttribute="top" secondItem="1MI-Rk-5WN" secondAttribute="bottom" id="H5y-KA-GCk"/>
                             <constraint firstAttribute="trailing" secondItem="1MI-Rk-5WN" secondAttribute="trailing" id="H9a-Kc-oAK"/>
+                            <constraint firstItem="Nft-qL-QZ9" firstAttribute="centerY" secondItem="3Qr-bd-WoG" secondAttribute="centerY" id="JED-Wj-JYl"/>
                             <constraint firstItem="Vyk-X1-klK" firstAttribute="top" secondItem="oDc-7s-ORm" secondAttribute="bottom" constant="16" id="L3n-Xr-76Y"/>
                             <constraint firstItem="3Qr-bd-WoG" firstAttribute="leading" secondItem="jGo-0u-sSj" secondAttribute="leading" constant="16" id="QIz-pt-XLo"/>
                             <constraint firstItem="oDc-7s-ORm" firstAttribute="top" secondItem="LOY-0w-MaL" secondAttribute="bottom" constant="8" id="QWe-rK-vQh"/>

--- a/EZAudioExamples/iOS/CoreGraphicsWaveform/CoreGraphicsWaveform/ViewController.h
+++ b/EZAudioExamples/iOS/CoreGraphicsWaveform/CoreGraphicsWaveform/ViewController.h
@@ -90,6 +90,11 @@
 - (IBAction)toggleMicrophonePickerView:(id)sender;
 
 //
+// Toggles the waveform fadeout on low levels.
+//
+- (IBAction)toggleFadeout:(id)sender;
+
+//
 // Toggles the microphone on and off. When the microphone is on it will send its
 // delegate (aka this view controller) the audio data in various ways (check out
 // the EZMicrophoneDelegate documentation for more details);

--- a/EZAudioExamples/iOS/CoreGraphicsWaveform/CoreGraphicsWaveform/ViewController.m
+++ b/EZAudioExamples/iOS/CoreGraphicsWaveform/CoreGraphicsWaveform/ViewController.m
@@ -88,6 +88,7 @@
     // Waveform color
     //
     self.audioPlot.color = [UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:1.0];
+    self.audioPlot.fadeOut = YES;
 
     //
     // Plot type
@@ -196,6 +197,14 @@
         [self.microphone startFetchingAudio];
         self.microphoneTextLabel.text = @"Microphone On";
     }
+}
+
+//------------------------------------------------------------------------------
+
+- (void)toggleFadeout:(id)sender
+{
+    BOOL isOn = [sender isOn];
+    self.audioPlot.fadeOut = isOn;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
I've added a boolean on the audioPlot, fadeout. If True, the wave form line will fade out when close to 0...I just didn't need the line sticking around in my particular case, so I threw this together. Could use some improvement, but it is off by default and might be useful for someone else.