### PR TITLE
Fixed a crash when creating EZAudioFile from iPod library

### DIFF
--- a/EZAudio/EZAudioFile.m
+++ b/EZAudio/EZAudioFile.m
@@ -250,7 +250,7 @@ typedef struct
     //
     // Create an ExtAudioFileRef for the file handle
     //
-    if (fileExists)
+    if (fileExists || [fileURL.absoluteString hasPrefix: @"ipod-library://"])
     {
         [EZAudioUtilities checkResult:ExtAudioFileOpenURL(url, &self.info->extAudioFileRef)
                             operation:"Failed to create ExtAudioFileRef"];


### PR DESCRIPTION
On iOS, App will be crashed when creating `EZAudioFile` from iPod Library.
Because, always returns `NO` at [here](https://github.com/syedhali/EZAudio/blob/1.1.5/EZAudio/EZAudioFile.m#L260).
(Maybe, iOS can't check file existence of iPod library by `NSFileManager#fileExistsAtPath`.)

This pull request add the condition to avoid file existence check in case of iPod library.

This crash discussed in the following issue: #222 