### PR TITLE
freeHistoryInfo was freeing memory in the wrong order causing memory …

### DIFF
--- a/EZAudio/EZAudioUtilities.m
+++ b/EZAudio/EZAudioUtilities.m
@@ -709,9 +709,9 @@ BOOL __shouldExitOnCheckResultFail = YES;
 
 + (void)freeHistoryInfo:(EZPlotHistoryInfo *)historyInfo
 {
+    TPCircularBufferCleanup(&historyInfo->circularBuffer);
     free(historyInfo->buffer);
     free(historyInfo);
-    TPCircularBufferCleanup(&historyInfo->circularBuffer);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
…corruption and crashes